### PR TITLE
Updates for latest FMS and FV

### DIFF
--- a/GEOSdynamicsPert_GridComp/fvdycorepert/model/fv_control.F90
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/model/fv_control.F90
@@ -32,7 +32,7 @@ module fv_control_mod
    use mpp_mod,             only: FATAL, mpp_error, mpp_pe, stdlog, &
                                   mpp_npes, mpp_get_current_pelist, &
                                   input_nml_file, get_unit, WARNING, &
-                                  read_ascii_file, INPUT_STR_LENGTH
+                                  read_ascii_file
    use mpp_domains_mod,     only: mpp_get_data_domain, mpp_get_compute_domain
    use tracer_manager_mod,  only: tm_get_number_tracers => get_number_tracers, &
                                   tm_get_tracer_index   => get_tracer_index,   &


### PR DESCRIPTION
The latest FMS and FV in GEOSgcm v11.6.0 has some edits from our JEDI colleagues. One of the changes was the removal of `INPUT_STR_LENGTH` from mpp. So, we need to remove it from pert's dynamics as well.

