### PR TITLE
Fix for ESMF Config Table Handling and Timers

### DIFF
--- a/GEOS_AgcmPertGridComp.F90
+++ b/GEOS_AgcmPertGridComp.F90
@@ -459,22 +459,6 @@ contains
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC, name="RUN"        , RC=STATUS)
     VERIFY_(STATUS)
-    call MAPL_TimerAdd(GC, name="--RUNTLM"   , RC=STATUS)
-    VERIFY_(STATUS)
-    call MAPL_TimerAdd(GC, name="----RunDynaTLM", RC=STATUS)
-    VERIFY_(STATUS)
-#ifndef NO_PHYSCOMP_
-    call MAPL_TimerAdd(GC, name="----RunPhysTLM", RC=STATUS)
-    VERIFY_(STATUS)
-#endif
-    call MAPL_TimerAdd(GC, name="--RUNADJ"   , RC=STATUS)
-    VERIFY_(STATUS)
-    call MAPL_TimerAdd(GC, name="----RunDynaADJ", RC=STATUS)
-    VERIFY_(STATUS)
-#ifndef NO_PHYSCOMP_
-    call MAPL_TimerAdd(GC, name="----RunPhysADJ", RC=STATUS)
-    VERIFY_(STATUS)
-#endif
     call MAPL_TimerAdd(GC, name="FINALIZE"   , RC=STATUS)
     VERIFY_(STATUS)
 

--- a/GEOS_AgcmPertGridComp.F90
+++ b/GEOS_AgcmPertGridComp.F90
@@ -2900,6 +2900,7 @@ subroutine Run(gc, import, export, clock, rc)
     character(len=ESMF_MAXSTR), parameter :: IAm="gq_"
 
     character(len=ESMF_MAXSTR) :: charbuf
+    logical :: tend
     integer :: STATUS, RC
 
     ! initialize
@@ -2908,11 +2909,11 @@ subroutine Run(gc, import, export, clock, rc)
 
     ! go to the desired label in resource file
     CALL ESMF_ConfigFindLabel(CF, label = 'TRAJ_FILE::', __RC__ )
-    do
-      CALL ESMF_ConfigNextLine    (CF,          __RC__)
-      CALL ESMF_ConfigGetAttribute(CF, charbuf, __RC__)
-      if ( trim(charbuf) == '::' ) exit
-      ntrj = ntrj + 1
+    tend = .false.
+    do while (.not. tend)
+      CALL ESMF_ConfigGetAttribute(CF, value=charbuf, default='', __RC__)
+      if ( trim(charbuf) /= '' ) ntrj = ntrj + 1
+      CALL ESMF_ConfigNextLine    (CF, tableEnd=tend, __RC__)
     end do
 
     ! get the wght's for quadrature based on number of points

--- a/GEOSphysicsPert_GridComp/GEOSmoistPert_GridComp/GEOS_MoistPertGridComp.F90
+++ b/GEOSphysicsPert_GridComp/GEOSmoistPert_GridComp/GEOS_MoistPertGridComp.F90
@@ -100,7 +100,7 @@ contains
     VERIFY_(STATUS)
     call MAPL_TimerAdd(GC,   name="RUNADJ"       ,RC=STATUS)
     VERIFY_(STATUS)
-    call MAPL_TimerAdd(GC,   name="-MOIST"       ,RC=STATUS)
+    call MAPL_TimerAdd(GC,   name="MOIST"       ,RC=STATUS)
     VERIFY_(STATUS)
 
 ! The same run method is registered twice
@@ -239,12 +239,6 @@ subroutine Run(gc, import, export, clock, rc)
     call MAPL_GetObjectFromGC (GC, MAPL,  RC=STATUS )
     VERIFY_(STATUS)
 
-! Turn on MAPL timers
-! -------------------
-    call MAPL_TimerOn(MAPL,"TOTAL")
-    call MAPL_TimerOn(MAPL,"-MOIST")
-    call MAPL_TimerOn(MAPL,PHASE_NAME)
-
 ! Get time step of the linear model
 ! ---------------------------------
     call MAPL_GetResource(MAPL, DT, Label="RUN_DT:", RC=STATUS)
@@ -260,6 +254,12 @@ subroutine Run(gc, import, export, clock, rc)
     case default
        ASSERT_(.false.)
     end select
+
+! Turn on MAPL timers
+! -------------------
+    call MAPL_TimerOn(MAPL,"TOTAL")
+    call MAPL_TimerOn(MAPL,"MOIST")
+    call MAPL_TimerOn(MAPL,PHASE_NAME)
 
 ! Begin linearised moist physics calculations if asked for in AGCM_apert
 ! ----------------------------------------------------------------------
@@ -1013,7 +1013,7 @@ subroutine Run(gc, import, export, clock, rc)
 ! --------
     call MAPL_TimerOff(MAPL,PHASE_NAME) 
     call MAPL_TimerOff(MAPL,"TOTAL")
-    call MAPL_TimerOff(MAPL,"-MOIST")
+    call MAPL_TimerOff(MAPL,"MOIST")
 
     RETURN_(ESMF_SUCCESS)
 


### PR DESCRIPTION
## Trajectory Config Issue

@rtodling found an issue with GEOSadas v5.43.0 where the Pert code was throwing weird errors/crashing in reading trajectory files.

The issue seems to be due to newer ESMF (after v8.6.0 per an email chain with @rtodling and @bena-nasa) where config file handling is now done by hconfig (internally) and table ends must be handled differently:

> Looks like something changed between 8.6.0 and subsequent releases. Was able to confirm that v8.6.0 still “worked” with that existing code. I’ll talk to them today. Incidentally UFS + Gocart hit the same issue process a different table with different code.

> So they did change that, but talked to them; now have a tableEnd argument that returns true if the “::” is encountered. So that routine you had to parse the line should look like this now, when you do ESMF_ConfigNextLine, add the tableEnd argument and just return if tableEnd is true.

This PR changes it to be like other places in GEOS. Indeed there was a change a couple years ago in the GSI which [altered code to be like this](https://github.com/GEOS-ESM/GEOSana_GridComp/blob/e1e170de430c766dfa57a1bbc4c7abd09fedcd2b/GEOSaana_GridComp/GSI_GridComp/GSI_GridCompMod.F90#L3472-L3492) in https://github.com/GEOS-ESM/GEOSana_GridComp/pull/184

In this case, we borrowed the style from the [History Grid Comp](https://github.com/GEOS-ESM/MAPL/blob/7447e3d95f740eca0cfc321c672dced0c750c893/gridcomps/History/MAPL_HistoryGridComp.F90#L570-L591). You have to be careful as you are incrementing a counter and you have to make sure not to increment it on the "last" `ConfigGetAttribute` where it's looking for the `tableEnd`.

## Timer issues

In testing the fix above, the run crashed at the end. This seems to be due to the timer issues that @bena-nasa fixed in [this commit](https://github.com/GEOS-ESM/GEOSagcmPert_GridComp/pull/7/changes/45a0a15670e859ebccc70cd9ffc7fa225ce6ea03) from #7.

NOTE: I did *NOT* take the other changes in #7. These [changes from @rtodling](https://github.com/GEOS-ESM/GEOSagcmPert_GridComp/pull/7/changes/fc5904127dcf5bed97acb432603cb0be02a415bc) seem to be more physical/scientific and beyond my purview. 