### PR TITLE
Fixes for FMS 2024

### DIFF
--- a/GEOSdynamicsPert_GridComp/fvdycorepert/CMakeLists.txt
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/CMakeLists.txt
@@ -81,11 +81,11 @@ set (SRCS
 
 esma_add_library (${this}
   SRCS ${SRCS}
-  DEPENDENCIES MAPL fms_r8 Tapenade
+  DEPENDENCIES MAPL FMS::fms_r8 Tapenade
   )
 
 target_compile_definitions (${this} PRIVATE MAPL_MODE SPMD TIMING USE_COND MAIST_CAPPA OLDMPP)
 esma_fortran_generator_list(${this} ${FREAL8})
 
 
-  
+

--- a/GEOSdynamicsPert_GridComp/fvdycorepert/model/boundary.F90
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/model/boundary.F90
@@ -105,7 +105,7 @@ contains
     else
        debug = .false.
     end if
-    
+
     if (is == 1) then
 
        if (pd) then
@@ -133,7 +133,7 @@ contains
           end do
 
        end if
-       
+
     end if
 
     if (js == 1) then
@@ -163,7 +163,7 @@ contains
           end do
 
        end if
-       
+
     end if
 
     if (ie == npx - 1) then
@@ -172,7 +172,7 @@ contains
 
           do j=jstart,jend+jstag
           do i=ie+1+istag,ied+istag
-             
+
              if (real(i) >= ie+istag + q(ie+istag,j)/(q(ie+istag-1,j)-q(ie+istag,j)+1.e-12) .and. &
                   q(ie+istag,j) < q(ie+istag-1,j)) then
                 q(i,j) = q(i-1,j)
@@ -243,7 +243,7 @@ contains
              else
                 q(i,j) = 0.5*( real(2-i)*q(1,j) - real(1-i)*q(2,j) )
              end if
-             
+
              if  (real(j) <= 1. - q(i,1)/(q(i,2) - q(i,1) + 1.e-12) .and. q(i,2) > q(i,1)) then
                 q(i,j) = q(i,j) + 0.5*q(i,j+1)
 
@@ -258,10 +258,10 @@ contains
 
           do j=jsd,0
           do i=isd,0
-                 
+
              q(i,j) = 0.5*( real(2-i)*q(1,j) - real(1-i)*q(2,j) ) + &
                   0.5*( real(2-j)*q(i,1) - real(1-j)*q(i,2) )
-             
+
           end do
           end do
 
@@ -290,7 +290,7 @@ contains
              else
                 q(i,j) = q(i,j) + 0.5*( real(j - (je+jstag-1))*q(i,je+jstag) + real((je+jstag) - j)*q(i,je+jstag-1) )
              end if
-                 
+
           end do
           end do
 
@@ -298,10 +298,10 @@ contains
 
           do j=je+1+jstag,jed+jstag
           do i=isd,0
-                 
+
              q(i,j) = 0.5*( real(2-i)*q(1,j) - real(1-i)*q(2,j) ) + &
                       0.5*( real(j - (je+jstag-1))*q(i,je+jstag) + real((je+jstag) - j)*q(i,je+jstag-1) )
-          
+
           end do
           end do
 
@@ -315,8 +315,8 @@ contains
 
           do j=je+1+jstag,jed+jstag
           do i=ie+1+istag,ied+istag
-                 
-             
+
+
              if (real(i) >= ie+istag + q(ie+istag,j)/(q(ie+istag-1,j)-q(ie+istag,j)+1.e-12) .and. &
                   q(ie+istag-1,j) > q(ie+istag,j)) then
                 q(i,j) = 0.5*q(i-1,j)
@@ -330,7 +330,7 @@ contains
              else
                 q(i,j) = q(i,j) + 0.5*( real(j - (je+jstag-1))*q(i,je+jstag) + real((je+jstag) - j)*q(i,je+jstag-1) )
              end if
-          
+
           end do
           end do
 
@@ -338,10 +338,10 @@ contains
 
           do j=je+1+jstag,jed+jstag
           do i=ie+1+istag,ied+istag
-                 
+
              q(i,j) = 0.5*( real(i - (ie+istag-1))*q(ie+istag,j) + real((ie+istag) - i)*q(ie+istag-1,j) ) + &
                       0.5*( real(j - (je+jstag-1))*q(i,je+jstag) + real((je+jstag) - j)*q(i,je+jstag-1) )
-          
+
           end do
           end do
 
@@ -355,22 +355,22 @@ contains
 
           do j=0,jsd,-1
           do i=ie+1+istag,ied+istag
-                 
-             
+
+
              if (real(i) >= ie+istag + q(ie+istag,j)/(q(ie+istag-1,j)-q(ie+istag,j)+1.e-12) .and. &
                   q(ie+istag-1,j) > q(ie+istag,j)) then
                 q(i,j) = 0.5*q(i-1,j)
              else
                 q(i,j) = 0.5*(real(i - (ie+istag-1))*q(ie+istag,j) + real((ie+istag) - i)*q(ie+istag-1,j))
              end if
-             
+
              if  (real(j) <= 1. - q(i,1)/(q(i,2) - q(i,1) + 1.e-12) .and. &
                   q(i,2) > q(i,1)) then
                 q(i,j) = q(i,j) + 0.5*q(i,j+1)
              else
                 q(i,j) = q(i,j) + 0.5*(real(2-j)*q(i,1) - real(1-j)*q(i,2))
              end if
-          
+
           end do
           end do
 
@@ -379,10 +379,10 @@ contains
 
           do j=jsd,0
           do i=ie+1+istag,ied+istag
-                 
+
              q(i,j) = 0.5*( real(i - (ie+istag-1))*q(ie+istag,j) + real((ie+istag) - i)*q(ie+istag-1,j) ) + &
                       0.5*( real(2-j)*q(i,1) - real(1-j)*q(i,2) )
-          
+
           end do
           end do
 
@@ -398,7 +398,7 @@ contains
 
    type(fv_grid_bounds_type), intent(IN) :: bd
    real, dimension(bd%isd:bd%ied+istag,bd%jsd:bd%jed+jstag), intent(INOUT) :: var_nest
-   real, dimension(isg:ieg+istag,jsg:jeg+jstag), intent(IN) :: var_coarse 
+   real, dimension(isg:ieg+istag,jsg:jeg+jstag), intent(IN) :: var_coarse
    integer, dimension(bd%isd:bd%ied+istag,bd%jsd:bd%jed+jstag,2), intent(IN) :: ind
    real, dimension(bd%isd:bd%ied+istag,bd%jsd:bd%jed+jstag,4), intent(IN) :: wt
    integer, intent(IN) :: istag, jstag, isg, ieg, jsg, jeg
@@ -451,13 +451,13 @@ contains
            wt(i,j,1)*var_coarse(ic,  jc) +  &
            wt(i,j,2)*var_coarse(ic,  jc+1) +  &
            wt(i,j,3)*var_coarse(ic+1,jc+1) +  &
-           wt(i,j,4)*var_coarse(ic+1,jc) 
+           wt(i,j,4)*var_coarse(ic+1,jc)
 
    end do
    end do
 
  end subroutine fill_nested_grid_2D
- 
+
   subroutine fill_nested_grid_3D(var_nest, var_coarse, ind, wt, istag, jstag,  &
       isg, ieg, jsg, jeg, npz, bd, istart_in, iend_in, jstart_in, jend_in)
 
@@ -518,7 +518,7 @@ contains
            wt(i,j,1)*var_coarse(ic,  jc,  k) +  &
            wt(i,j,2)*var_coarse(ic,  jc+1,k) +  &
            wt(i,j,3)*var_coarse(ic+1,jc+1,k) +  &
-           wt(i,j,4)*var_coarse(ic+1,jc,  k) 
+           wt(i,j,4)*var_coarse(ic+1,jc,  k)
 
    end do
    end do
@@ -526,7 +526,7 @@ contains
    end do
 
  end subroutine fill_nested_grid_3D
- 
+
  subroutine nested_grid_BC_mpp(var_nest, var_coarse, nest_domain, ind, wt, istag, jstag, &
       npx, npy, npz, bd, isg, ieg, jsg, jeg, nstep_in, nsplit_in, proc_in)
 
@@ -583,13 +583,13 @@ contains
    end if
 
    call mpp_get_C2F_index(nest_domain, isw_f, iew_f, jsw_f, jew_f, isw_c, iew_c, jsw_c, jew_c, &
-        WEST,  position=position)
+        WEST,  nest_level=0, position=position)
    call mpp_get_C2F_index(nest_domain, ise_f, iee_f, jse_f, jee_f, ise_c, iee_c, jse_c, jee_c, &
-        EAST,  position=position)
+        EAST,  nest_level=0, position=position)
    call mpp_get_C2F_index(nest_domain, iss_f, ies_f, jss_f, jes_f, iss_c, ies_c, jss_c, jes_c, &
-        SOUTH,  position=position)
+        SOUTH,  nest_level=0, position=position)
    call mpp_get_C2F_index(nest_domain, isn_f, ien_f, jsn_f, jen_f, isn_c, ien_c, jsn_c, jen_c, &
-        NORTH,  position=position)
+        NORTH,  nest_level=0, position=position)
 
    if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
       allocate(wbuffer(isw_c:iew_c, jsw_c:jew_c,npz))
@@ -621,7 +621,7 @@ contains
 
 
        call timing_on ('COMM_TOTAL')
-   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  position=position)
+   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  nest_level=0, position=position)
        call timing_off('COMM_TOTAL')
 
    if (process) then
@@ -638,7 +638,7 @@ contains
                  wt(i,j,1)*wbuffer(ic,  jc,  k) +  &
                  wt(i,j,2)*wbuffer(ic,  jc+1,k) +  &
                  wt(i,j,3)*wbuffer(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*wbuffer(ic+1,jc,  k) 
+                 wt(i,j,4)*wbuffer(ic+1,jc,  k)
 
          end do
       end do
@@ -670,7 +670,7 @@ contains
                  wt(i,j,1)*sbuffer(ic,  jc,  k) +  &
                  wt(i,j,2)*sbuffer(ic,  jc+1,k) +  &
                  wt(i,j,3)*sbuffer(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*sbuffer(ic+1,jc,  k) 
+                 wt(i,j,4)*sbuffer(ic+1,jc,  k)
 
          end do
       end do
@@ -690,7 +690,7 @@ contains
                  wt(i,j,1)*ebuffer(ic,  jc,  k) +  &
                  wt(i,j,2)*ebuffer(ic,  jc+1,k) +  &
                  wt(i,j,3)*ebuffer(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*ebuffer(ic+1,jc,  k) 
+                 wt(i,j,4)*ebuffer(ic+1,jc,  k)
 
          end do
       end do
@@ -722,7 +722,7 @@ contains
                  wt(i,j,1)*nbuffer(ic,  jc,  k) +  &
                  wt(i,j,2)*nbuffer(ic,  jc+1,k) +  &
                  wt(i,j,3)*nbuffer(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*nbuffer(ic+1,jc,  k) 
+                 wt(i,j,4)*nbuffer(ic+1,jc,  k)
 
          end do
       end do
@@ -772,7 +772,7 @@ contains
 
 
        call timing_on ('COMM_TOTAL')
-   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  position=position)
+   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  nest_level=0, position=position)
        call timing_off('COMM_TOTAL')
 
 
@@ -836,13 +836,13 @@ contains
    end if
 
    call mpp_get_C2F_index(nest_domain, isw_f, iew_f, jsw_f, jew_f, isw_c, iew_c, jsw_c, jew_c, &
-        WEST,  position=position)
+        WEST,  nest_level=0, position=position)
    call mpp_get_C2F_index(nest_domain, ise_f, iee_f, jse_f, jee_f, ise_c, iee_c, jse_c, jee_c, &
-        EAST,  position=position)
+        EAST,  nest_level=0, position=position)
    call mpp_get_C2F_index(nest_domain, iss_f, ies_f, jss_f, jes_f, iss_c, ies_c, jss_c, jes_c, &
-        SOUTH,  position=position)
+        SOUTH,  nest_level=0, position=position)
    call mpp_get_C2F_index(nest_domain, isn_f, ien_f, jsn_f, jen_f, isn_c, ien_c, jsn_c, jen_c, &
-        NORTH,  position=position)
+        NORTH,  nest_level=0, position=position)
 
    if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
       allocate(wbuffer(isw_c:iew_c, jsw_c:jew_c))
@@ -873,7 +873,7 @@ contains
    nbuffer = 0
 
        call timing_on ('COMM_TOTAL')
-   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  position=position)
+   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  nest_level=0, position=position)
        call timing_off('COMM_TOTAL')
 
    if (process) then
@@ -889,7 +889,7 @@ contains
                  wt(i,j,1)*wbuffer(ic,  jc) +  &
                  wt(i,j,2)*wbuffer(ic,  jc+1) +  &
                  wt(i,j,3)*wbuffer(ic+1,jc+1) +  &
-                 wt(i,j,4)*wbuffer(ic+1,jc) 
+                 wt(i,j,4)*wbuffer(ic+1,jc)
 
          end do
       end do
@@ -919,7 +919,7 @@ contains
                  wt(i,j,1)*sbuffer(ic,  jc) +  &
                  wt(i,j,2)*sbuffer(ic,  jc+1) +  &
                  wt(i,j,3)*sbuffer(ic+1,jc+1) +  &
-                 wt(i,j,4)*sbuffer(ic+1,jc) 
+                 wt(i,j,4)*sbuffer(ic+1,jc)
 
          end do
       end do
@@ -937,7 +937,7 @@ contains
                  wt(i,j,1)*ebuffer(ic,  jc) +  &
                  wt(i,j,2)*ebuffer(ic,  jc+1) +  &
                  wt(i,j,3)*ebuffer(ic+1,jc+1) +  &
-                 wt(i,j,4)*ebuffer(ic+1,jc) 
+                 wt(i,j,4)*ebuffer(ic+1,jc)
 
          end do
       end do
@@ -967,7 +967,7 @@ contains
                  wt(i,j,1)*nbuffer(ic,  jc) +  &
                  wt(i,j,2)*nbuffer(ic,  jc+1) +  &
                  wt(i,j,3)*nbuffer(ic+1,jc+1) +  &
-                 wt(i,j,4)*nbuffer(ic+1,jc) 
+                 wt(i,j,4)*nbuffer(ic+1,jc)
 
          end do
       end do
@@ -1025,7 +1025,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc) 
+                 wt(i,j,4)*var_coarse(ic+1,jc)
 
          end do
       end do
@@ -1055,7 +1055,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc) 
+                 wt(i,j,4)*var_coarse(ic+1,jc)
 
          end do
       end do
@@ -1073,7 +1073,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc) 
+                 wt(i,j,4)*var_coarse(ic+1,jc)
 
          end do
       end do
@@ -1104,7 +1104,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc) 
+                 wt(i,j,4)*var_coarse(ic+1,jc)
 
          end do
       end do
@@ -1161,7 +1161,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc,  k) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1,k) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc,  k) 
+                 wt(i,j,4)*var_coarse(ic+1,jc,  k)
 
          end do
       end do
@@ -1193,7 +1193,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc,  k) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1,k) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc,  k) 
+                 wt(i,j,4)*var_coarse(ic+1,jc,  k)
 
          end do
       end do
@@ -1213,7 +1213,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc,  k) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1,k) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc,  k) 
+                 wt(i,j,4)*var_coarse(ic+1,jc,  k)
 
          end do
       end do
@@ -1245,7 +1245,7 @@ contains
                  wt(i,j,1)*var_coarse(ic,  jc,  k) +  &
                  wt(i,j,2)*var_coarse(ic,  jc+1,k) +  &
                  wt(i,j,3)*var_coarse(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*var_coarse(ic+1,jc,  k) 
+                 wt(i,j,4)*var_coarse(ic+1,jc,  k)
 
          end do
       end do
@@ -1281,7 +1281,7 @@ contains
    end if
 
        call timing_on ('COMM_TOTAL')
-   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  position=position)
+   call mpp_update_nest_fine(var_coarse, nest_domain, wbuffer, sbuffer, ebuffer, nbuffer,  nest_level=0, position=position)
        call timing_off('COMM_TOTAL')
 
  end subroutine nested_grid_BC_send
@@ -1294,7 +1294,7 @@ contains
    integer, intent(IN) :: istag, jstag, npz
 
    type(fv_nest_BC_type_3d), intent(INOUT), target :: nest_BC_buffers
-   
+
    real, dimension(bd%isd:bd%ied+istag,bd%jsd:bd%jed+jstag,npz) :: var_coarse_dummy
 
    integer                      :: position
@@ -1319,13 +1319,13 @@ contains
    if (.not. allocated(nest_BC_buffers%west_t1) ) then
 
       call mpp_get_C2F_index(nest_domain, isw_f, iew_f, jsw_f, jew_f, isw_c, iew_c, jsw_c, jew_c, &
-           WEST,  position=position)
+           WEST,  nest_level=0, position=position)
       call mpp_get_C2F_index(nest_domain, ise_f, iee_f, jse_f, jee_f, ise_c, iee_c, jse_c, jee_c, &
-           EAST,  position=position)
+           EAST,  nest_level=0, position=position)
       call mpp_get_C2F_index(nest_domain, iss_f, ies_f, jss_f, jes_f, iss_c, ies_c, jss_c, jes_c, &
-           SOUTH,  position=position)
+           SOUTH,  nest_level=0, position=position)
       call mpp_get_C2F_index(nest_domain, isn_f, ien_f, jsn_f, jen_f, isn_c, ien_c, jsn_c, jen_c, &
-           NORTH,  position=position)
+           NORTH,  nest_level=0, position=position)
 
       if( iew_c .GE. isw_c .AND. jew_c .GE. jsw_c ) then
          If (.not. allocated(nest_BC_buffers%west_t1)) allocate(nest_BC_buffers%west_t1(isw_c:iew_c, jsw_c:jew_c,npz))
@@ -1336,7 +1336,7 @@ contains
             nest_BC_buffers%west_t1(i,j,k) = 0.
          enddo
          enddo
-         enddo         
+         enddo
       else
          allocate(nest_BC_buffers%west_t1(1,1,1))
          nest_BC_buffers%west_t1(1,1,1) = 0.
@@ -1387,7 +1387,7 @@ contains
    endif
 
        call timing_on ('COMM_TOTAL')
-   call mpp_update_nest_fine(var_coarse_dummy, nest_domain, nest_BC_buffers%west_t1, nest_BC_buffers%south_t1, nest_BC_buffers%east_t1, nest_BC_buffers%north_t1,  position=position)
+   call mpp_update_nest_fine(var_coarse_dummy, nest_domain, nest_BC_buffers%west_t1, nest_BC_buffers%south_t1, nest_BC_buffers%east_t1, nest_BC_buffers%north_t1,  nest_level=0, position=position)
        call timing_off('COMM_TOTAL')
 
  end subroutine nested_grid_BC_recv
@@ -1405,7 +1405,7 @@ contains
    !!NOTE: if declaring an ALLOCATABLE array with intent(OUT), the resulting dummy array
    !!      will NOT be allocated! This goes for allocatable members of derived types as well.
    type(fv_nest_BC_type_3d), intent(INOUT), target :: nest_BC, nest_BC_buffers
-   
+
    real, dimension(bd%isd:bd%ied+istag,bd%jsd:bd%jed+jstag,npz) :: var_coarse_dummy
 
    real, dimension(:,:,:), pointer :: var_east, var_west, var_south, var_north
@@ -1463,7 +1463,7 @@ contains
                  wt(i,j,1)*buf_west(ic,  jc,k) +  &
                  wt(i,j,2)*buf_west(ic,  jc+1,k) +  &
                  wt(i,j,3)*buf_west(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*buf_west(ic+1,jc,k) 
+                 wt(i,j,4)*buf_west(ic+1,jc,k)
 
          end do
       end do
@@ -1478,7 +1478,7 @@ contains
             var_west(i,j,k) = max(var_west(i,j,k), 0.5*nest_BC%west_t0(i,j,k))
          end do
          end do
-         end do         
+         end do
       endif
 
    end if
@@ -1510,7 +1510,7 @@ contains
                  wt(i,j,1)*buf_south(ic,  jc,k) +  &
                  wt(i,j,2)*buf_south(ic,  jc+1,k) +  &
                  wt(i,j,3)*buf_south(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*buf_south(ic+1,jc,k) 
+                 wt(i,j,4)*buf_south(ic+1,jc,k)
 
          end do
       end do
@@ -1526,7 +1526,7 @@ contains
 
          end do
          end do
-         end do         
+         end do
       endif
 
    end if
@@ -1547,7 +1547,7 @@ contains
                  wt(i,j,1)*buf_east(ic,  jc,k) +  &
                  wt(i,j,2)*buf_east(ic,  jc+1,k) +  &
                  wt(i,j,3)*buf_east(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*buf_east(ic+1,jc,k) 
+                 wt(i,j,4)*buf_east(ic+1,jc,k)
 
          end do
       end do
@@ -1563,7 +1563,7 @@ contains
 
          end do
          end do
-         end do         
+         end do
       endif
 
    end if
@@ -1595,7 +1595,7 @@ contains
                  wt(i,j,1)*buf_north(ic,  jc,k) +  &
                  wt(i,j,2)*buf_north(ic,  jc+1,k) +  &
                  wt(i,j,3)*buf_north(ic+1,jc+1,k) +  &
-                 wt(i,j,4)*buf_north(ic+1,jc,k) 
+                 wt(i,j,4)*buf_north(ic+1,jc,k)
 
          end do
       end do
@@ -1611,7 +1611,7 @@ contains
 
          end do
          end do
-         end do         
+         end do
       endif
 
    end if
@@ -1619,7 +1619,7 @@ contains
  end subroutine nested_grid_BC_save_proc
 
 
-  ! A NOTE ON BCTYPE: currently only an interpolation BC is implemented, 
+  ! A NOTE ON BCTYPE: currently only an interpolation BC is implemented,
   ! bctype >= 2 currently correspond
   ! to a flux BC on the tracers ONLY, which is implemented in fv_tracer.
 
@@ -1632,7 +1632,7 @@ contains
    integer, intent(IN) :: istag, jstag, npx, npy, npz
    real, intent(IN) :: split, step
    integer, intent(IN) :: bctype
-   
+
    type(fv_nest_BC_type_3D), intent(IN), target :: BC
    real, pointer, dimension(:,:,:) :: var_t0, var_t1
 
@@ -1816,7 +1816,7 @@ contains
       position = CENTER
    end if
 
-   call mpp_get_F2C_index(nest_domain, is_c, ie_c, js_c, je_c, is_f, ie_f, js_f, je_f, position=position)
+   call mpp_get_F2C_index(nest_domain, is_c, ie_c, js_c, je_c, is_f, ie_f, js_f, je_f, nest_level=0, position=position)
    if (ie_f > is_f .and. je_f > js_f) then
       allocate(nest_dat (is_f:ie_f, js_f:je_f,npz))
    else
@@ -1829,7 +1829,7 @@ contains
    if (istag == 0 .and. jstag == 0) then
       select case (nestupdate)
       case (1,2,6,7,8)
-         
+
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,area)
          do k=1,npz
          do j=js_n,je_n
@@ -1845,7 +1845,7 @@ contains
       end select
    else if (istag == 0 .and. jstag > 0) then
 
-      select case (nestupdate) 
+      select case (nestupdate)
       case (1,6,7,8)
 
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,dx)
@@ -1855,7 +1855,7 @@ contains
 
 
             var_nest_send(i,j,k) = var_nest(i,j,k)*dx(i,j)
-            
+
          end do
          end do
          end do
@@ -1867,7 +1867,7 @@ contains
       end select
 
    else if (istag > 0 .and. jstag == 0) then
-      select case (nestupdate) 
+      select case (nestupdate)
 
       case (1,6,7,8)   !averaging update; in-line average for face-averaged values instead of areal average
 
@@ -1889,14 +1889,14 @@ contains
       end select
 
    else
-      
+
       call mpp_error(FATAL, "Cannot have both nonzero istag and jstag.")
 
    endif
    endif
 
       call timing_on('COMM_TOTAL')
-   call mpp_update_nest_coarse(var_nest_send, nest_domain, nest_dat, position=position)
+   call mpp_update_nest_coarse(var_nest_send, nest_domain, nest_dat, nest_level=0, position=position)
       call timing_off('COMM_TOTAL')
 
    s = r/2 !rounds down (since r > 0)
@@ -1905,7 +1905,7 @@ contains
    if (parent_proc .and. .not. (ieu < isu .or. jeu < jsu)) then
    if (istag == 0 .and. jstag == 0) then
 
-      select case (nestupdate) 
+      select case (nestupdate)
       case (1,2,6,7,8) ! 1 = Conserving update on all variables; 2 = conserving update for cell-centered values; 6 = conserving remap-update
 
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
@@ -1928,7 +1928,7 @@ contains
                do ini=in,in+r-1
                   val = val + nest_dat(ini,jnj,k)
                end do
-            end do            
+            end do
 
             !var_coarse(i,j,k) = val/r**2.
 
@@ -1951,7 +1951,7 @@ contains
    else if (istag == 0 .and. jstag > 0) then
 
 
-      select case (nestupdate) 
+      select case (nestupdate)
       case (1,6,7,8)
 
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
@@ -1989,7 +1989,7 @@ contains
 
    else if (istag > 0 .and. jstag == 0) then
 
-      select case (nestupdate) 
+      select case (nestupdate)
       case (1,6,7,8)   !averaging update; in-line average for face-averaged values instead of areal average
 
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
@@ -2030,9 +2030,9 @@ contains
 
    endif
    deallocate(nest_dat)
-   
+
  end subroutine update_coarse_grid_mpp
 
 
-   
+
 end module boundary_mod

--- a/GEOSdynamicsPert_GridComp/fvdycorepert/model/fv_control.F90
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/model/fv_control.F90
@@ -76,32 +76,32 @@ module fv_control_mod
    character(len=80) , pointer :: grid_name
    character(len=120), pointer :: grid_file
    integer, pointer :: grid_type
-   integer , pointer :: hord_mt 
-   integer , pointer :: kord_mt 
-   integer , pointer :: kord_wz 
-   integer , pointer :: hord_vt 
-   integer , pointer :: hord_tm 
-   integer , pointer :: hord_dp 
-   integer , pointer :: kord_tm 
-   integer , pointer :: hord_tr 
-   integer , pointer :: kord_tr 
-   real    , pointer :: scale_z 
-   real    , pointer :: w_max 
-   real    , pointer :: z_min 
+   integer , pointer :: hord_mt
+   integer , pointer :: kord_mt
+   integer , pointer :: kord_wz
+   integer , pointer :: hord_vt
+   integer , pointer :: hord_tm
+   integer , pointer :: hord_dp
+   integer , pointer :: kord_tm
+   integer , pointer :: hord_tr
+   integer , pointer :: kord_tr
+   real    , pointer :: scale_z
+   real    , pointer :: w_max
+   real    , pointer :: z_min
 
    integer , pointer :: nord
    integer , pointer :: nord_tr
-   real    , pointer :: dddmp 
-   real    , pointer :: d2_bg 
-   real    , pointer :: d4_bg 
-   real    , pointer :: vtdm4 
-   real    , pointer :: trdm2 
-   real    , pointer :: d2_bg_k1 
-   real    , pointer :: d2_bg_k2 
-   real    , pointer :: d2_divg_max_k1 
-   real    , pointer :: d2_divg_max_k2 
-   real    , pointer :: damp_k_k1 
-   real    , pointer :: damp_k_k2 
+   real    , pointer :: dddmp
+   real    , pointer :: d2_bg
+   real    , pointer :: d4_bg
+   real    , pointer :: vtdm4
+   real    , pointer :: trdm2
+   real    , pointer :: d2_bg_k1
+   real    , pointer :: d2_bg_k2
+   real    , pointer :: d2_divg_max_k1
+   real    , pointer :: d2_divg_max_k2
+   real    , pointer :: damp_k_k1
+   real    , pointer :: damp_k_k2
    integer , pointer ::    n_zs_filter
    integer , pointer :: nord_zs_filter
    logical , pointer :: full_zs_filter
@@ -109,111 +109,111 @@ module fv_control_mod
    logical , pointer :: consv_am
    logical , pointer :: do_sat_adj
    logical , pointer :: do_f3d
-   logical , pointer :: no_dycore 
-   logical , pointer :: convert_ke 
-   logical , pointer :: do_vort_damp 
-   logical , pointer :: use_old_omega 
+   logical , pointer :: no_dycore
+   logical , pointer :: convert_ke
+   logical , pointer :: do_vort_damp
+   logical , pointer :: use_old_omega
 ! PG off centering:
-   real    , pointer :: beta  
+   real    , pointer :: beta
    integer , pointer :: n_zfilter
-   integer , pointer :: n_sponge 
-   real    , pointer :: d_ext 
-   integer , pointer :: nwat  
-   logical , pointer :: warm_start 
-   logical , pointer :: inline_q 
-   real , pointer :: shift_fac   
-   logical , pointer :: do_schmidt 
-   real(kind=R_GRID) , pointer :: stretch_fac 
-   real(kind=R_GRID) , pointer :: target_lat  
-   real(kind=R_GRID) , pointer :: target_lon  
+   integer , pointer :: n_sponge
+   real    , pointer :: d_ext
+   integer , pointer :: nwat
+   logical , pointer :: warm_start
+   logical , pointer :: inline_q
+   real , pointer :: shift_fac
+   logical , pointer :: do_schmidt
+   real(kind=R_GRID) , pointer :: stretch_fac
+   real(kind=R_GRID) , pointer :: target_lat
+   real(kind=R_GRID) , pointer :: target_lon
 
-   logical , pointer :: reset_eta 
+   logical , pointer :: reset_eta
    real    , pointer :: p_fac
    real    , pointer :: a_imp
-   integer , pointer :: n_split 
-                             ! Default 
-   integer , pointer :: m_split 
-   integer , pointer :: k_split 
+   integer , pointer :: n_split
+                             ! Default
+   integer , pointer :: m_split
+   integer , pointer :: k_split
    logical , pointer :: use_logp
 
-   integer , pointer :: q_split 
-   integer , pointer :: print_freq 
+   integer , pointer :: q_split
+   integer , pointer :: print_freq
 
-   integer , pointer :: npx           
-   integer , pointer :: npy           
-   integer , pointer :: npz           
-   integer , pointer :: npz_rst 
-                                      
-   integer , pointer :: ncnst 
-   integer , pointer :: pnats 
-   integer , pointer :: dnats 
-   integer , pointer :: ntiles        
-   integer , pointer :: nf_omega  
-   integer , pointer :: fv_sg_adj 
-                                      
-   integer , pointer :: na_init 
-   real    , pointer :: p_ref 
-   real    , pointer :: dry_mass 
-   integer , pointer :: nt_prog 
-   integer , pointer :: nt_phys 
-   real    , pointer :: tau_h2o 
+   integer , pointer :: npx
+   integer , pointer :: npy
+   integer , pointer :: npz
+   integer , pointer :: npz_rst
+
+   integer , pointer :: ncnst
+   integer , pointer :: pnats
+   integer , pointer :: dnats
+   integer , pointer :: ntiles
+   integer , pointer :: nf_omega
+   integer , pointer :: fv_sg_adj
+
+   integer , pointer :: na_init
+   real    , pointer :: p_ref
+   real    , pointer :: dry_mass
+   integer , pointer :: nt_prog
+   integer , pointer :: nt_phys
+   real    , pointer :: tau_h2o
 
    real    , pointer :: delt_max
-   real    , pointer :: d_con 
+   real    , pointer :: d_con
    real    , pointer :: ke_bg
-   real    , pointer :: consv_te 
-   real    , pointer :: tau 
+   real    , pointer :: consv_te
+   real    , pointer :: tau
    real    , pointer :: rf_cutoff
-   logical , pointer :: filter_phys 
-   logical , pointer :: dwind_2d 
-   logical , pointer :: breed_vortex_inline 
-   logical , pointer :: range_warn 
-   logical , pointer :: fill 
-   logical , pointer :: fill_dp 
-   logical , pointer :: fill_wz 
+   logical , pointer :: filter_phys
+   logical , pointer :: dwind_2d
+   logical , pointer :: breed_vortex_inline
+   logical , pointer :: range_warn
+   logical , pointer :: fill
+   logical , pointer :: fill_dp
+   logical , pointer :: fill_wz
    logical , pointer :: check_negative
-   logical , pointer :: non_ortho 
-   logical , pointer :: adiabatic 
-   logical , pointer :: moist_phys 
-   logical , pointer :: do_Held_Suarez 
+   logical , pointer :: non_ortho
+   logical , pointer :: adiabatic
+   logical , pointer :: moist_phys
+   logical , pointer :: do_Held_Suarez
    logical , pointer :: do_reed_physics
    logical , pointer :: reed_cond_only
-   logical , pointer :: reproduce_sum 
-   logical , pointer :: adjust_dry_mass 
-   logical , pointer :: fv_debug  
-   logical , pointer :: srf_init  
-   logical , pointer :: mountain  
-   integer , pointer :: remap_option  
-   logical , pointer :: z_tracer 
+   logical , pointer :: reproduce_sum
+   logical , pointer :: adjust_dry_mass
+   logical , pointer :: fv_debug
+   logical , pointer :: srf_init
+   logical , pointer :: mountain
+   integer , pointer :: remap_option
+   logical , pointer :: z_tracer
 
-   logical , pointer :: old_divg_damp 
-   logical , pointer :: fv_land 
-   logical , pointer :: nudge 
+   logical , pointer :: old_divg_damp
+   logical , pointer :: fv_land
+   logical , pointer :: nudge
    logical , pointer :: nudge_ic
-   logical , pointer :: ncep_ic 
-   logical , pointer :: nggps_ic 
-   logical , pointer :: ecmwf_ic 
+   logical , pointer :: ncep_ic
+   logical , pointer :: nggps_ic
+   logical , pointer :: ecmwf_ic
    logical , pointer :: gfs_phil
    logical , pointer :: agrid_vel_rst
-   logical , pointer :: use_new_ncep 
-   logical , pointer :: use_ncep_phy 
-   logical , pointer :: fv_diag_ic 
-   logical , pointer :: external_ic 
+   logical , pointer :: use_new_ncep
+   logical , pointer :: use_ncep_phy
+   logical , pointer :: fv_diag_ic
+   logical , pointer :: external_ic
    character(len=128) , pointer :: res_latlon_dynamics
-   character(len=128) , pointer :: res_latlon_tracers 
-   logical , pointer :: hydrostatic 
+   character(len=128) , pointer :: res_latlon_tracers
+   logical , pointer :: hydrostatic
    logical , pointer :: phys_hydrostatic
    logical , pointer :: use_hydro_pressure
    logical , pointer :: do_uni_zfull !miz
    logical , pointer :: adj_mass_vmr ! f1p
-   logical , pointer :: hybrid_z    
-   logical , pointer :: Make_NH     
-   logical , pointer :: make_hybrid_z  
+   logical , pointer :: hybrid_z
+   logical , pointer :: Make_NH
+   logical , pointer :: make_hybrid_z
    logical , pointer :: nudge_qv
    real,     pointer :: add_noise
 
-   integer , pointer :: a2b_ord 
-   integer , pointer :: c2l_ord 
+   integer , pointer :: a2b_ord
+   integer , pointer :: c2l_ord
 
    integer, pointer :: ndims
 
@@ -286,7 +286,7 @@ module fv_control_mod
    call setup_pointers(Atm(1))
 
  end subroutine fv_init1
-         
+
  subroutine fv_init2(Atm, dt_atmos, grids_on_this_pe, p_split)
 
    type(fv_atmos_type), allocatable, intent(inout), target :: Atm(:)
@@ -311,7 +311,7 @@ module fv_control_mod
       call timing_init
       call timing_on('TOTAL')
 
-    ! Setup the run from namelist 
+    ! Setup the run from namelist
       ntilesMe = size(Atm(:)) !Full number of Atm arrays; one less than number of grids, if multiple grids
 
       call run_setup(Atm,dt_atmos, grids_on_this_pe, p_split)   ! initializes domain_decomp
@@ -321,7 +321,7 @@ module fv_control_mod
          !In a single-grid run this will still be needed to correctly set the domain
          call switch_current_Atm(Atm(n))
          call setup_pointers(Atm(n))
-         
+
          target_lon = target_lon * pi/180.
          target_lat = target_lat * pi/180.
 
@@ -332,7 +332,7 @@ module fv_control_mod
          !not sure if this works with multiple grids
          call tm_register_tracers (MODEL_ATMOS, ncnst, nt_prog, pnats, num_family)
          if(is_master()) then
-            write(*,*) 'ncnst=', ncnst,' num_prog=',nt_prog,' pnats=',pnats,' dnats=',dnats,' num_family=',num_family         
+            write(*,*) 'ncnst=', ncnst,' num_prog=',nt_prog,' pnats=',pnats,' dnats=',dnats,' num_family=',num_family
             print*, ''
          endif
 
@@ -411,7 +411,7 @@ module fv_control_mod
                call mpp_get_global_domain( Atm(n)%parent_grid%domain, &
                     isg, ieg, jsg, jeg)
 
-               !FIXME: Should replace this by generating the global grid (or at least one face thereof) on the 
+               !FIXME: Should replace this by generating the global grid (or at least one face thereof) on the
                ! nested PEs instead of sending it around.
                if (gid == Atm(n)%parent_grid%pelist(1)) then
                      call mpp_send(Atm(n)%parent_grid%grid_global(isg-ng:ieg+1+ng,jsg-ng:jeg+1+ng,1:2,parent_tile), &
@@ -483,7 +483,7 @@ module fv_control_mod
             endif
          endif
       end do
-      
+
     ! Initialize restart functions
       call fv_restart_init()
 
@@ -501,7 +501,7 @@ module fv_control_mod
 !-------------------------------------------------------------------------------
 
 !-------------------------------------------------------------------------------
-         
+
  subroutine fv_end(Atm, grids_on_this_pe, restarts)
 
     type(fv_atmos_type), intent(inout) :: Atm(:)
@@ -545,7 +545,7 @@ module fv_control_mod
 
       real :: dim0 = 180.           ! base dimension
       real :: dt0  = 1800.          ! base time step
-      real :: ns0  = 5.             ! base nsplit for base dimension 
+      real :: ns0  = 5.             ! base nsplit for base dimension
                                     ! For cubed sphere 5 is better
       !real :: umax = 350.           ! max wave speed for grid_type>3 ! Now defined above
       real :: dimx, dl, dp, dxmin, dymin, d_fac
@@ -602,7 +602,7 @@ module fv_control_mod
 
       inquire(file=filename,exist=exists)
       if (.not. exists) then  ! This will be replaced with fv_error wrapper
-        if(is_master()) write(*,*) "file ",trim(filename)," doesn't exist" 
+        if(is_master()) write(*,*) "file ",trim(filename)," doesn't exist"
         call mpp_error(FATAL,'FV core terminating 1')
      endif
 
@@ -640,7 +640,7 @@ module fv_control_mod
          if (size(Atm) > 1) then
             call mpp_error(FATAL, "Nesting not implemented with INTERNAL_FILE_NML")
          endif
-   ! Read FVCORE namelist 
+   ! Read FVCORE namelist
       read (input_nml_file,fv_core_nml,iostat=ios)
       ierr = check_nml_error(ios,'fv_core_nml')
    ! Read Test_Case namelist
@@ -665,12 +665,12 @@ module fv_control_mod
          f_unit = open_namelist_file()
       else if (n == 1) then
          f_unit = open_namelist_file('input.nml')
-      else 
+      else
          write(nested_grid_filename,'(A10, I2.2, A4)') 'input_nest', n, '.nml'
          f_unit = open_namelist_file(nested_grid_filename)
       endif
 
-   ! Read FVCORE namelist 
+   ! Read FVCORE namelist
       read (f_unit,fv_core_nml,iostat=ios)
       ierr = check_nml_error(ios,'fv_core_nml')
 
@@ -694,7 +694,7 @@ module fv_control_mod
       endif
 #endif
       call close_file(f_unit)
-#endif         
+#endif
           if (len_trim(grid_file) /= 0) Atm(n)%flagstruct%grid_file = grid_file
           if (len_trim(grid_name) /= 0) Atm(n)%flagstruct%grid_name = grid_name
           if (len_trim(res_latlon_dynamics) /= 0) Atm(n)%flagstruct%res_latlon_dynamics = res_latlon_dynamics
@@ -704,7 +704,7 @@ module fv_control_mod
          write(unit, nml=test_case_nml)
 #ifdef GFS_PHYS
          write(unit, nml=nggps_diag_nml)
-#endif         
+#endif
 
          !*** single tile for Cartesian grids
          if (grid_type>3) then
@@ -734,7 +734,7 @@ module fv_control_mod
       else
          dimx = max ( npx, 2*(npy-1) )
       endif
-          
+
       if (grid_type < 4) then
          n0split = nint ( ns0*abs(dt_atmos)*dimx/(dt0*dim0) + 0.49 )
       elseif (grid_type == 4 .or. grid_type == 7) then
@@ -808,8 +808,8 @@ module fv_control_mod
 
       else
          Atm(n)%neststruct%ioffset                = -999
-         Atm(n)%neststruct%joffset                = -999   
-         Atm(n)%neststruct%parent_tile            = -1      
+         Atm(n)%neststruct%joffset                = -999
+         Atm(n)%neststruct%parent_tile            = -1
          Atm(n)%neststruct%refinement             = -1
       end if
 
@@ -895,7 +895,7 @@ module fv_control_mod
    enddo
 
    do n=1,size(Atm)
-      
+
       call switch_current_Atm(Atm(n),.false.)
       call setup_pointers(Atm(n))
       !! CLEANUP: WARNING not sure what changes to domain_decomp may cause
@@ -914,22 +914,22 @@ module fv_control_mod
       if (nested) then
          if (mod(npx-1 , refinement) /= 0 .or. mod(npy-1, refinement) /= 0) &
               call mpp_error(FATAL, 'npx or npy not an even refinement of its coarse grid.')
-         
+
          !Pelist needs to be set to ALL (which should have been done
          !in broadcast_domains) to get this to work
-         call mpp_define_nest_domains(Atm(n)%neststruct%nest_domain, Atm(n)%domain, Atm(parent_grid_num)%domain, &
-              7, parent_tile, &
-              1, npx-1, 1, npy-1,                  & !Grid cells, not points
-              ioffset, ioffset + (npx-1)/refinement - 1, &
-              joffset, joffset + (npy-1)/refinement - 1,         &
-              (/ (i,i=0,mpp_npes()-1)  /), extra_halo = 0, name="nest_domain") !What pelist to use?
-         call mpp_define_nest_domains(Atm(n)%neststruct%nest_domain, Atm(n)%domain, Atm(parent_grid_num)%domain, &
-              7, parent_tile, &
-              1, npx-1, 1, npy-1,                  & !Grid cells, not points
-              ioffset, ioffset + (npx-1)/refinement - 1, &
-              joffset, joffset + (npy-1)/refinement - 1,         &
-              (/ (i,i=0,mpp_npes()-1)  /), extra_halo = 0, name="nest_domain") !What pelist to use?
-!              (/ (i,i=0,mpp_npes()-1)  /), extra_halo = 2, name="nest_domain_for_BC") !What pelist to use?
+         !call mpp_define_nest_domains(Atm(n)%neststruct%nest_domain, Atm(n)%domain, Atm(parent_grid_num)%domain, &
+              !7, parent_tile, &
+              !1, npx-1, 1, npy-1,                  & !Grid cells, not points
+              !ioffset, ioffset + (npx-1)/refinement - 1, &
+              !joffset, joffset + (npy-1)/refinement - 1,         &
+              !(/ (i,i=0,mpp_npes()-1)  /), extra_halo = 0, name="nest_domain") !What pelist to use?
+         !call mpp_define_nest_domains(Atm(n)%neststruct%nest_domain, Atm(n)%domain, Atm(parent_grid_num)%domain, &
+              !7, parent_tile, &
+              !1, npx-1, 1, npy-1,                  & !Grid cells, not points
+              !ioffset, ioffset + (npx-1)/refinement - 1, &
+              !joffset, joffset + (npy-1)/refinement - 1,         &
+              !(/ (i,i=0,mpp_npes()-1)  /), extra_halo = 0, name="nest_domain") !What pelist to use?
+!!              (/ (i,i=0,mpp_npes()-1)  /), extra_halo = 2, name="nest_domain_for_BC") !What pelist to use?
 
          Atm(parent_grid_num)%neststruct%child_grids(n) = .true.
 
@@ -970,7 +970,7 @@ module fv_control_mod
   end subroutine run_setup
 
   subroutine init_nesting(Atm, grids_on_this_pe, p_split)
-    
+
     type(fv_atmos_type), intent(inout), allocatable :: Atm(:)
    logical, allocatable, intent(INOUT) :: grids_on_this_pe(:)
     integer, intent(INOUT) :: p_split
@@ -1003,7 +1003,7 @@ module fv_control_mod
       if (ngrids > 10) call mpp_error(FATAL, "More than 10 nested grids not supported")
 
       allocate(Atm(ngrids))
-    
+
       allocate(grids_on_this_pe(ngrids))
       grids_on_this_pe = .false. !initialization
 
@@ -1234,7 +1234,7 @@ module fv_control_mod
      a2b_ord                       => Atm%flagstruct%a2b_ord
      c2l_ord                       => Atm%flagstruct%c2l_ord
      ndims                         => Atm%flagstruct%ndims
-    
+
      dx_const                      => Atm%flagstruct%dx_const
      dy_const                      => Atm%flagstruct%dy_const
      deglon_start                  => Atm%flagstruct%deglon_start
@@ -1259,5 +1259,5 @@ module fv_control_mod
      io_layout                     => Atm%io_layout
   end subroutine setup_pointers
 
-       
+
 end module fv_control_mod

--- a/GEOSdynamicsPert_GridComp/fvdycorepert/model_tlmadm/boundary_adm.F90
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/model_tlmadm/boundary_adm.F90
@@ -1355,7 +1355,7 @@ CONTAINS
 !_Super fv_dynamics_mod.Rayleigh_Friction fv_dynamics_mod.compute_aam fv_grid_utils_mod.cubed_to_latlon fv_grid_utils_mod.c2l_ord
 !4 fv_grid_utils_mod.c2l_ord2 fv_mapz_mod.Lagrangian_to_Eulerian fv_mapz_mod.compute_total_energy fv_mapz_mod.pkez fv_mapz_mod.re
 !map_z fv_mapz_mod.map_scalar fv_mapz_mod.map1_ppm fv_mapz_mod.mapn_tracer fv_mapz_mod.map1_q2 fv_mapz_mod.remap_2d f
-!v_mapz_mod.scalar_profile fv_mapz_mod.cs_profile fv_mapz_mod.cs_limiters fv_mapz_mod.ppm_profile fv_mapz_mod.ppm_limiters 
+!v_mapz_mod.scalar_profile fv_mapz_mod.cs_profile fv_mapz_mod.cs_limiters fv_mapz_mod.ppm_profile fv_mapz_mod.ppm_limiters
 !fv_mapz_mod.steepz fv_mapz_mod.rst_remap fv_mapz_mod.mappm fv_mapz_mod.moist_cv fv_mapz_mod.moist_cp fv_mapz_mod.map1_cubic fv_r
 !estart_mod.d2c_setup fv_tracer2d_mod.tracer_2d_1L fv_tracer2d_mod.tracer_2d fv_tracer2d_mod.tracer_2d_nested fv_sg_mod.fv_subgri
 !d_z main_mod.compute_pressures main_mod.run nh_core_mod.Riem_Solver3 nh_utils_mod.update_dz_c nh_utils_mod.update_dz_d nh_utils_
@@ -1671,8 +1671,8 @@ CONTAINS
     IF (child_proc) THEN
 !! IF an area average (for istag == jstag == 0) or a linear average then multiply in the areas before sending data
       IF (istag .EQ. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 2, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 2, 6, 7, 8)
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,area)
           DO k=1,npz
             DO j=js_n,je_n
@@ -1683,8 +1683,8 @@ CONTAINS
           END DO
         END SELECT
       ELSE IF (istag .EQ. 0 .AND. jstag .GT. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,dx)
           DO k=1,npz
             DO j=js_n,je_n+1
@@ -1697,8 +1697,8 @@ CONTAINS
           CALL MPP_ERROR(fatal, 'nestupdate type not implemented')
         END SELECT
       ELSE IF (istag .GT. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !averaging update; in-line average for face-averaged values instead of areal average
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,dy)
           DO k=1,npz
@@ -1718,15 +1718,15 @@ CONTAINS
     END IF
     CALL TIMING_ON('COMM_TOTAL')
     CALL MPP_UPDATE_NEST_COARSE(var_nest_send, nest_domain, nest_dat, &
-&                         position=position)
+&                         nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
 !rounds down (since r > 0)
     s = r/2
     qr = r*upoff + nsponge - s
     IF (parent_proc .AND. (.NOT.(ieu .LT. isu .OR. jeu .LT. jsu))) THEN
       IF (istag .EQ. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 2, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 2, 6, 7, 8)
 ! 1 = Conserving update on all variables; 2 = conserving update for cell-centered values; 6 = conserving remap-update
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
 !$NO-MP          private(in,jn,val)
@@ -1737,7 +1737,7 @@ CONTAINS
                 jn = ind_update(i, j, 2)
 !!$            if (in < max(1+qr,is_f) .or. in > min(npx-1-qr-r+1,ie_f) .or. &
 !!$                 jn < max(1+qr,js_f) .or. jn > min(npy-1-qr-r+1,je_f)) then
-!!$               write(mpp_pe()+3000,'(A, 14I6)') 'SKIP: ', i, j, in, jn, 1+qr, is_f, ie_f, js_f, je_f, npy-1-qr-r+1, isu, ieu, 
+!!$               write(mpp_pe()+3000,'(A, 14I6)') 'SKIP: ', i, j, in, jn, 1+qr, is_f, ie_f, js_f, je_f, npy-1-qr-r+1, isu, ieu,
 !jsu, jeu
 !!$               cycle
 !!$            endif
@@ -1759,8 +1759,8 @@ CONTAINS
           CALL MPP_ERROR(fatal, 'nestupdate type not implemented')
         END SELECT
       ELSE IF (istag .EQ. 0 .AND. jstag .GT. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
 !$NO-MP          private(in,jn,val)
           DO k=1,npz
@@ -1788,8 +1788,8 @@ CONTAINS
           CALL MPP_ERROR(fatal, 'nestupdate type not implemented')
         END SELECT
       ELSE IF (istag .GT. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !averaging update; in-line average for face-averaged values instead of areal average
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
 !$NO-MP          private(in,jn,val)

--- a/GEOSdynamicsPert_GridComp/fvdycorepert/model_tlmadm/boundary_tlm.F90
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/model_tlmadm/boundary_tlm.F90
@@ -507,13 +507,13 @@ CONTAINS
       position = center
     END IF
     CALL MPP_GET_C2F_INDEX(nest_domain, isw_f, iew_f, jsw_f, jew_f, &
-&                    isw_c, iew_c, jsw_c, jew_c, west, position)
+&                    isw_c, iew_c, jsw_c, jew_c, west, nest_level=0, position=position)
     CALL MPP_GET_C2F_INDEX(nest_domain, ise_f, iee_f, jse_f, jee_f, &
-&                    ise_c, iee_c, jse_c, jee_c, east, position)
+&                    ise_c, iee_c, jse_c, jee_c, east, nest_level=0, position=position)
     CALL MPP_GET_C2F_INDEX(nest_domain, iss_f, ies_f, jss_f, jes_f, &
-&                    iss_c, ies_c, jss_c, jes_c, south, position)
+&                    iss_c, ies_c, jss_c, jes_c, south, nest_level=0, position=position)
     CALL MPP_GET_C2F_INDEX(nest_domain, isn_f, ien_f, jsn_f, jen_f, &
-&                    isn_c, ien_c, jsn_c, jen_c, north, position)
+&                    isn_c, ien_c, jsn_c, jen_c, north, nest_level=0, position=position)
     IF (iew_c .GE. isw_c .AND. jew_c .GE. jsw_c) THEN
       ALLOCATE(wbuffer(isw_c:iew_c, jsw_c:jew_c, npz))
     ELSE
@@ -540,7 +540,7 @@ CONTAINS
     nbuffer = 0.0
     CALL TIMING_ON('COMM_TOTAL')
     CALL MPP_UPDATE_NEST_FINE(var_coarse, nest_domain, wbuffer, sbuffer&
-&                       , ebuffer, nbuffer, position)
+&                       , ebuffer, nbuffer, nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
 !process
     IF (process) THEN
@@ -649,7 +649,7 @@ CONTAINS
     ALLOCATE(nbuffer(1, 1, 1))
     CALL TIMING_ON('COMM_TOTAL')
     CALL MPP_UPDATE_NEST_FINE(var_coarse, nest_domain, wbuffer, sbuffer&
-&                       , ebuffer, nbuffer, position)
+&                       , ebuffer, nbuffer, nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
     DEALLOCATE(wbuffer)
     DEALLOCATE(ebuffer)
@@ -710,13 +710,13 @@ CONTAINS
       position = center
     END IF
     CALL MPP_GET_C2F_INDEX(nest_domain, isw_f, iew_f, jsw_f, jew_f, &
-&                    isw_c, iew_c, jsw_c, jew_c, west, position)
+&                    isw_c, iew_c, jsw_c, jew_c, west, nest_level=0, position=position)
     CALL MPP_GET_C2F_INDEX(nest_domain, ise_f, iee_f, jse_f, jee_f, &
-&                    ise_c, iee_c, jse_c, jee_c, east, position)
+&                    ise_c, iee_c, jse_c, jee_c, east, nest_level=0, position=position)
     CALL MPP_GET_C2F_INDEX(nest_domain, iss_f, ies_f, jss_f, jes_f, &
-&                    iss_c, ies_c, jss_c, jes_c, south, position)
+&                    iss_c, ies_c, jss_c, jes_c, south, nest_level=0, position=position)
     CALL MPP_GET_C2F_INDEX(nest_domain, isn_f, ien_f, jsn_f, jen_f, &
-&                    isn_c, ien_c, jsn_c, jen_c, north, position)
+&                    isn_c, ien_c, jsn_c, jen_c, north, nest_level=0, position=position)
     IF (iew_c .GE. isw_c .AND. jew_c .GE. jsw_c) THEN
       ALLOCATE(wbuffer(isw_c:iew_c, jsw_c:jew_c))
     ELSE
@@ -743,7 +743,7 @@ CONTAINS
     nbuffer = 0.0
     CALL TIMING_ON('COMM_TOTAL')
     CALL MPP_UPDATE_NEST_FINE(var_coarse, nest_domain, wbuffer, sbuffer&
-&                       , ebuffer, nbuffer, position)
+&                       , ebuffer, nbuffer, nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
 !process
     IF (process) THEN
@@ -1045,7 +1045,7 @@ CONTAINS
     END IF
     CALL TIMING_ON('COMM_TOTAL')
     CALL MPP_UPDATE_NEST_FINE(var_coarse, nest_domain, wbuffer, sbuffer&
-&                       , ebuffer, nbuffer, position)
+&                       , ebuffer, nbuffer, nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
   END SUBROUTINE NESTED_GRID_BC_SEND
   SUBROUTINE NESTED_GRID_BC_RECV(nest_domain, istag, jstag, npz, bd, &
@@ -1076,13 +1076,13 @@ CONTAINS
     END IF
     IF (.NOT.ALLOCATED(nest_bc_buffers%west_t1)) THEN
       CALL MPP_GET_C2F_INDEX(nest_domain, isw_f, iew_f, jsw_f, jew_f, &
-&                      isw_c, iew_c, jsw_c, jew_c, west, position)
+&                      isw_c, iew_c, jsw_c, jew_c, west, nest_level=0, position=position)
       CALL MPP_GET_C2F_INDEX(nest_domain, ise_f, iee_f, jse_f, jee_f, &
-&                      ise_c, iee_c, jse_c, jee_c, east, position)
+&                      ise_c, iee_c, jse_c, jee_c, east, nest_level=0, position=position)
       CALL MPP_GET_C2F_INDEX(nest_domain, iss_f, ies_f, jss_f, jes_f, &
-&                      iss_c, ies_c, jss_c, jes_c, south, position)
+&                      iss_c, ies_c, jss_c, jes_c, south, nest_level=0, position=position)
       CALL MPP_GET_C2F_INDEX(nest_domain, isn_f, ien_f, jsn_f, jen_f, &
-&                      isn_c, ien_c, jsn_c, jen_c, north, position)
+&                      isn_c, ien_c, jsn_c, jen_c, north, nest_level=0, position=position)
       IF (iew_c .GE. isw_c .AND. jew_c .GE. jsw_c) THEN
         IF (.NOT.ALLOCATED(nest_bc_buffers%west_t1)) THEN
           ALLOCATE(nest_bc_buffers%west_t1(isw_c:iew_c, jsw_c:jew_c, npz&
@@ -1153,7 +1153,7 @@ CONTAINS
     CALL MPP_UPDATE_NEST_FINE(var_coarse_dummy, nest_domain, &
 &                       nest_bc_buffers%west_t1, nest_bc_buffers%&
 &                       south_t1, nest_bc_buffers%east_t1, &
-&                       nest_bc_buffers%north_t1, position)
+&                       nest_bc_buffers%north_t1, nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
   END SUBROUTINE NESTED_GRID_BC_RECV
   SUBROUTINE NESTED_GRID_BC_SAVE_PROC(nest_domain, ind, wt, istag, jstag&
@@ -1627,7 +1627,7 @@ CONTAINS
       position = center
     END IF
     CALL MPP_GET_F2C_INDEX(nest_domain, is_c, ie_c, js_c, je_c, is_f, &
-&                    ie_f, js_f, je_f, position)
+&                    ie_f, js_f, je_f, nest_level=0, position=position)
     IF (ie_f .GT. is_f .AND. je_f .GT. js_f) THEN
       ALLOCATE(nest_dat(is_f:ie_f, js_f:je_f, npz))
     ELSE
@@ -1637,8 +1637,8 @@ CONTAINS
     IF (child_proc) THEN
 !! IF an area average (for istag == jstag == 0) or a linear average then multiply in the areas before sending data
       IF (istag .EQ. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 2, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 2, 6, 7, 8)
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,area)
           DO k=1,npz
             DO j=js_n,je_n
@@ -1649,8 +1649,8 @@ CONTAINS
           END DO
         END SELECT
       ELSE IF (istag .EQ. 0 .AND. jstag .GT. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,dx)
           DO k=1,npz
             DO j=js_n,je_n+1
@@ -1663,8 +1663,8 @@ CONTAINS
           CALL MPP_ERROR(fatal, 'nestupdate type not implemented')
         END SELECT
       ELSE IF (istag .GT. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !averaging update; in-line average for face-averaged values instead of areal average
 !$NO-MP parallel do default(none) shared(npz,js_n,je_n,is_n,ie_n,var_nest_send,var_nest,dy)
           DO k=1,npz
@@ -1684,15 +1684,15 @@ CONTAINS
     END IF
     CALL TIMING_ON('COMM_TOTAL')
     CALL MPP_UPDATE_NEST_COARSE(var_nest_send, nest_domain, nest_dat, &
-&                         position=position)
+&                         nest_level=0, position=position)
     CALL TIMING_OFF('COMM_TOTAL')
 !rounds down (since r > 0)
     s = r/2
     qr = r*upoff + nsponge - s
     IF (parent_proc .AND. (.NOT.(ieu .LT. isu .OR. jeu .LT. jsu))) THEN
       IF (istag .EQ. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 2, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 2, 6, 7, 8)
 ! 1 = Conserving update on all variables; 2 = conserving update for cell-centered values; 6 = conserving remap-update
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
 !$NO-MP          private(in,jn,val)
@@ -1703,7 +1703,7 @@ CONTAINS
                 jn = ind_update(i, j, 2)
 !!$            if (in < max(1+qr,is_f) .or. in > min(npx-1-qr-r+1,ie_f) .or. &
 !!$                 jn < max(1+qr,js_f) .or. jn > min(npy-1-qr-r+1,je_f)) then
-!!$               write(mpp_pe()+3000,'(A, 14I6)') 'SKIP: ', i, j, in, jn, 1+qr, is_f, ie_f, js_f, je_f, npy-1-qr-r+1, isu, ieu, 
+!!$               write(mpp_pe()+3000,'(A, 14I6)') 'SKIP: ', i, j, in, jn, 1+qr, is_f, ie_f, js_f, je_f, npy-1-qr-r+1, isu, ieu,
 !jsu, jeu
 !!$               cycle
 !!$            endif
@@ -1725,8 +1725,8 @@ CONTAINS
           CALL MPP_ERROR(fatal, 'nestupdate type not implemented')
         END SELECT
       ELSE IF (istag .EQ. 0 .AND. jstag .GT. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
 !$NO-MP          private(in,jn,val)
           DO k=1,npz
@@ -1754,8 +1754,8 @@ CONTAINS
           CALL MPP_ERROR(fatal, 'nestupdate type not implemented')
         END SELECT
       ELSE IF (istag .GT. 0 .AND. jstag .EQ. 0) THEN
-        SELECT CASE  (nestupdate) 
-        CASE (1, 6, 7, 8) 
+        SELECT CASE  (nestupdate)
+        CASE (1, 6, 7, 8)
 !averaging update; in-line average for face-averaged values instead of areal average
 !$NO-MP parallel do default(none) shared(npz,jsu,jeu,isu,ieu,ind_update,nest_dat,parent_grid,var_coarse,r) &
 !$NO-MP          private(in,jn,val)
@@ -1787,5 +1787,5 @@ CONTAINS
     END IF
     DEALLOCATE(nest_dat)
   END SUBROUTINE UPDATE_COARSE_GRID_MPP
-   
+
 end module boundary_tlm_mod

--- a/GEOSdynamicsPert_GridComp/fvdycorepert/tools/fv_mp_mod.F90
+++ b/GEOSdynamicsPert_GridComp/fvdycorepert/tools/fv_mp_mod.F90
@@ -27,7 +27,7 @@
 ! !USES:
       use fms_mod,         only : fms_init, fms_end
       use mpp_mod,         only : FATAL, MPP_DEBUG, NOTE, MPP_CLOCK_SYNC,MPP_CLOCK_DETAILED, WARNING
-      use mpp_mod,         only : mpp_pe, mpp_npes, mpp_node, mpp_root_pe, mpp_error, mpp_set_warn_level
+      use mpp_mod,         only : mpp_pe, mpp_npes, mpp_root_pe, mpp_error, mpp_set_warn_level
       use mpp_mod,         only : mpp_declare_pelist, mpp_set_current_pelist, mpp_sync
       use mpp_mod,         only : mpp_clock_begin, mpp_clock_end, mpp_clock_id
       use mpp_mod,         only : mpp_chksum, stdout, stderr, mpp_broadcast
@@ -38,7 +38,7 @@
       use mpp_domains_mod, only : mpp_get_compute_domain, mpp_get_data_domain, mpp_domains_set_stack_size
       use mpp_domains_mod, only : mpp_global_field, mpp_global_sum, mpp_global_max, mpp_global_min
       use mpp_domains_mod, only : mpp_domains_init, mpp_domains_exit, mpp_broadcast_domain
-      use mpp_domains_mod, only : mpp_check_field, mpp_define_layout 
+      use mpp_domains_mod, only : mpp_check_field, mpp_define_layout
       use mpp_domains_mod, only : mpp_get_neighbor_pe, mpp_define_mosaic, mpp_define_io_domain
       use mpp_domains_mod, only : NORTH, NORTH_EAST, EAST, SOUTH_EAST
       use mpp_domains_mod, only : SOUTH, SOUTH_WEST, WEST, NORTH_WEST
@@ -80,13 +80,13 @@
 
       type(nest_domain_type), allocatable, dimension(:)       :: nest_domain
       integer :: this_pe_grid = 0
-      integer, EXTERNAL :: omp_get_thread_num, omp_get_num_threads      
+      integer, EXTERNAL :: omp_get_thread_num, omp_get_num_threads
 
       integer :: npes_this_grid
 
       !! CLEANUP: these are currently here for convenience
       !! Right now calling switch_current_atm sets these to the value on the "current" grid
-      !!  (as well as changing the "current" domain) 
+      !!  (as well as changing the "current" domain)
       integer :: is, ie, js, je
       integer :: isd, ied, jsd, jed
       integer :: isc, iec, jsc, jec
@@ -241,7 +241,7 @@ contains
         integer, intent(IN) :: pelist_local(:)
 
         if (ANY(gid == pelist_local)) then
-        
+
            masterproc = pelist_local(1)
            master = (gid == masterproc)
 
@@ -255,11 +255,11 @@ contains
 !     mp_barrier :: Wait for all SPMD processes
 !
       subroutine mp_barrier()
-        
+
          call MPI_BARRIER(commglobal, ierror)
-      
+
       end subroutine mp_barrier
-!       
+!
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
 !-------------------------------------------------------------------------------
 
@@ -297,12 +297,12 @@ contains
 
          integer :: nx,ny,n,num_alloc
          character(len=32) :: type = "unknown"
-         logical :: is_symmetry 
+         logical :: is_symmetry
          logical :: debug=.false.
          integer, allocatable :: tile_id(:)
 
          integer i
-         integer :: npes_x, npes_y 
+         integer :: npes_x, npes_y
 
          integer, pointer :: pelist(:), grid_number, num_contact, npes_per_tile
          logical, pointer :: square_domain
@@ -353,7 +353,7 @@ contains
                is_symmetry = .true.
                call mpp_define_layout( (/1,npx-1,1,npy-1/), npes_per_tile, layout )
 
-               if ( npes_x == 0 ) then 
+               if ( npes_x == 0 ) then
                   npes_x = layout(1)
                endif
                if ( npes_y == 0 ) then
@@ -367,7 +367,7 @@ contains
                  call mp_stop
                  call exit(1)
               endif
-           
+
               layout = (/npes_x,npes_y/)
             case (3)   ! Lat-Lon "cyclic"
                type="Lat-Lon: cyclic"
@@ -425,7 +425,7 @@ contains
             endif
             call  mpp_define_layout( (/1,npx-1,1,npy-1/), npes_per_tile, layout )
 
-            if ( npes_x == 0 ) then 
+            if ( npes_x == 0 ) then
                npes_x = layout(1)
             endif
             if ( npes_y == 0 ) then
@@ -440,7 +440,7 @@ contains
                call mp_stop
                call exit(1)
             endif
-           
+
             layout = (/npes_x,npes_y/)
          case default
             call mpp_error(FATAL, 'domain_decomp: no such test: '//type)
@@ -459,7 +459,7 @@ contains
          allocate(tile1(num_alloc), tile2(num_alloc) )
          allocate(istart1(num_alloc), iend1(num_alloc), jstart1(num_alloc), jend1(num_alloc) )
          allocate(istart2(num_alloc), iend2(num_alloc), jstart2(num_alloc), jend2(num_alloc) )
- 
+
          is_symmetry = .true.
          select case(nregions)
          case ( 1 )
@@ -609,13 +609,13 @@ contains
        deallocate(istart2, iend2, jstart2, jend2)
 
        !--- find the tile number
-       Atm%tile = (gid-pelist(1))/npes_per_tile+1 
+       Atm%tile = (gid-pelist(1))/npes_per_tile+1
        if (ANY(pelist == gid)) then
           npes_this_grid = npes_per_tile*nregions
           tile = Atm%tile
           call mpp_get_compute_domain( domain, is,  ie,  js,  je  )
           call mpp_get_data_domain   ( domain, isd, ied, jsd, jed )
-          
+
           Atm%bd%is = is
           Atm%bd%js = js
           Atm%bd%ie = ie
@@ -639,7 +639,7 @@ contains
           endif
 200       format(i4.4, ' ', i4.4, ' ', i4.4, ' ', i4.4, ' ', i4.4, ' ')
        else
-          
+
           Atm%bd%is = 0
           Atm%bd%js = 0
           Atm%bd%ie = -1
@@ -672,18 +672,18 @@ subroutine start_var_group_update_2d(group, array, domain, flags, position, whal
   logical,      optional,       intent(in)    :: complete
   real                                        :: d_type
   logical                                     :: is_complete
-! Arguments: 
-!  (inout)   group - The data type that store information for group update. 
+! Arguments:
+!  (inout)   group - The data type that store information for group update.
 !                    This data will be used in do_group_pass.
 !  (inout)   array - The array which is having its halos points exchanged.
 !  (in)      domain - contains domain information.
 !  (in)      flags  - An optional integer indicating which directions the
-!                       data should be sent.  
+!                       data should be sent.
 !  (in)      position - An optional argument indicating the position.  This is
 !                       may be CORNER, but is CENTER by default.
 !  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second 
-!                       pass_..._start call.  Omitting complete is the same as 
+!                       should be initiated immediately or wait for second
+!                       pass_..._start call.  Omitting complete is the same as
 !                       setting complete to .true.
 
   if (mpp_group_update_initialized(group)) then
@@ -695,7 +695,7 @@ subroutine start_var_group_update_2d(group, array, domain, flags, position, whal
 
   is_complete = .TRUE.
   if(present(complete)) is_complete = complete
-  if(is_complete .and. halo_update_type == 1) then 
+  if(is_complete .and. halo_update_type == 1) then
      call mpp_start_group_update(group, domain, d_type)
   endif
 
@@ -713,18 +713,18 @@ subroutine start_var_group_update_3d(group, array, domain, flags, position, whal
   real                                        :: d_type
   logical                                     :: is_complete
 
-! Arguments: 
-!  (inout)   group - The data type that store information for group update. 
+! Arguments:
+!  (inout)   group - The data type that store information for group update.
 !                    This data will be used in do_group_pass.
 !  (inout)   array - The array which is having its halos points exchanged.
 !  (in)      domain - contains domain information.
 !  (in)      flags  - An optional integer indicating which directions the
-!                       data should be sent.  
+!                       data should be sent.
 !  (in)      position - An optional argument indicating the position.  This is
 !                       may be CORNER, but is CENTER by default.
 !  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second 
-!                       pass_..._start call.  Omitting complete is the same as 
+!                       should be initiated immediately or wait for second
+!                       pass_..._start call.  Omitting complete is the same as
 !                       setting complete to .true.
 
   if (mpp_group_update_initialized(group)) then
@@ -753,18 +753,18 @@ subroutine start_var_group_update_4d(group, array, domain, flags, position, whal
   real                                        :: d_type
   logical                                     :: is_complete
 
-! Arguments: 
-!  (inout)   group - The data type that store information for group update. 
+! Arguments:
+!  (inout)   group - The data type that store information for group update.
 !                    This data will be used in do_group_pass.
 !  (inout)   array - The array which is having its halos points exchanged.
 !  (in)      domain - contains domain information.
 !  (in)      flags  - An optional integer indicating which directions the
-!                       data should be sent.  
+!                       data should be sent.
 !  (in)      position - An optional argument indicating the position.  This is
 !                       may be CORNER, but is CENTER by default.
 !  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second 
-!                       pass_..._start call.  Omitting complete is the same as 
+!                       should be initiated immediately or wait for second
+!                       pass_..._start call.  Omitting complete is the same as
 !                       setting complete to .true.
 
   integer :: dirflag
@@ -797,22 +797,22 @@ subroutine start_vector_group_update_2d(group, u_cmpt, v_cmpt, domain, flags, gr
   real                                        :: d_type
   logical                                     :: is_complete
 
-! Arguments: 
-!  (inout)   group - The data type that store information for group update. 
+! Arguments:
+!  (inout)   group - The data type that store information for group update.
 !                    This data will be used in do_group_pass.
 !  (inout)   u_cmpt - The nominal zonal (u) component of the vector pair which
 !                     is having its halos points exchanged.
 !  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged. 
+!                     which is having its halos points exchanged.
 !  (in)      domain - Contains domain decomposition information.
 !  (in)      flags - An optional integer indicating which directions the
-!                        data should be sent. 
+!                        data should be sent.
 !  (in)      gridtype - An optional flag, which may be one of A_GRID, BGRID_NE,
 !                      CGRID_NE or DGRID_NE, indicating where the two components of the
-!                      vector are discretized. 
+!                      vector are discretized.
 !  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second 
-!                       pass_..._start call.  Omitting complete is the same as 
+!                       should be initiated immediately or wait for second
+!                       pass_..._start call.  Omitting complete is the same as
 !                       setting complete to .true.
 
   if (mpp_group_update_initialized(group)) then
@@ -842,22 +842,22 @@ subroutine start_vector_group_update_3d(group, u_cmpt, v_cmpt, domain, flags, gr
   real                                        :: d_type
   logical                                     :: is_complete
 
-! Arguments: 
-!  (inout)   group - The data type that store information for group update. 
+! Arguments:
+!  (inout)   group - The data type that store information for group update.
 !                    This data will be used in do_group_pass.
 !  (inout)   u_cmpt - The nominal zonal (u) component of the vector pair which
 !                     is having its halos points exchanged.
 !  (inout)   v_cmpt - The nominal meridional (v) component of the vector pair
-!                     which is having its halos points exchanged. 
+!                     which is having its halos points exchanged.
 !  (in)      domain - Contains domain decomposition information.
 !  (in)      flags - An optional integer indicating which directions the
-!                        data should be sent. 
+!                        data should be sent.
 !  (in)      gridtype - An optional flag, which may be one of A_GRID, BGRID_NE,
 !                      CGRID_NE or DGRID_NE, indicating where the two components of the
-!                      vector are discretized. 
+!                      vector are discretized.
 !  (in)      complete - An optional argument indicating whether the halo updates
-!                       should be initiated immediately or wait for second 
-!                       pass_..._start call.  Omitting complete is the same as 
+!                       should be initiated immediately or wait for second
+!                       pass_..._start call.  Omitting complete is the same as
 !                       setting complete to .true.
 
   if (mpp_group_update_initialized(group)) then
@@ -882,8 +882,8 @@ subroutine complete_group_halo_update(group, domain)
   type(domain2d),               intent(inout) :: domain
   real                                        :: d_type
 
-! Arguments: 
-!  (inout)   group - The data type that store information for group update. 
+! Arguments:
+!  (inout)   group - The data type that store information for group update.
 !  (in)      domain - Contains domain decomposition information.
 
   if( halo_update_type == 1 ) then
@@ -898,7 +898,7 @@ end subroutine complete_group_halo_update
 
 
 subroutine broadcast_domains(Atm)
-  
+
   type(fv_atmos_type), intent(INOUT) :: Atm(:)
 
   integer :: n, i1, i2, j1, j2, i
@@ -927,7 +927,7 @@ subroutine switch_current_domain(new_domain,new_domain_for_coupler)
   logical, parameter :: debug = .FALSE.
 
   !--- find the tile number
-  !tile = mpp_pe()/npes_per_tile+1 
+  !tile = mpp_pe()/npes_per_tile+1
   !ntiles = mpp_get_ntile_count(new_domain)
   call mpp_get_compute_domain( new_domain, is,  ie,  js,  je  )
   isc = is ; jsc = js
@@ -965,12 +965,12 @@ end subroutine switch_current_Atm
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !!
-!     
+!
       subroutine fill_corners_2d_r4(q, npx, npy, FILL, AGRID, BGRID)
          real(kind=4), DIMENSION(isd:,jsd:), intent(INOUT):: q
          integer, intent(IN):: npx,npy
-         integer, intent(IN):: FILL  ! X-Dir or Y-Dir 
-         logical, OPTIONAL, intent(IN) :: AGRID, BGRID 
+         integer, intent(IN):: FILL  ! X-Dir or Y-Dir
+         logical, OPTIONAL, intent(IN) :: AGRID, BGRID
          integer :: i,j
 
          if (present(BGRID)) then
@@ -979,7 +979,7 @@ end subroutine switch_current_Atm
               case (XDir)
                  do j=1,ng
                     do i=1,ng
-                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner 
+                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner
                      if ((is==    1) .and. (je==npy-1)) q(1-i  ,npy+j) = q(1-j  ,npy-i  )  !NW Corner
                      if ((ie==npx-1) .and. (js==    1)) q(npx+i,1-j  ) = q(npx+j,i+1    )  !SE Corner
                      if ((ie==npx-1) .and. (je==npy-1)) q(npx+i,npy+j) = q(npx+j,npy-i  )  !NE Corner
@@ -988,7 +988,7 @@ end subroutine switch_current_Atm
               case (YDir)
                  do j=1,ng
                     do i=1,ng
-                     if ((is==    1) .and. (js==    1)) q(1-j  ,1-i  ) = q(i+1  ,1-j    )  !SW Corner 
+                     if ((is==    1) .and. (js==    1)) q(1-j  ,1-i  ) = q(i+1  ,1-j    )  !SW Corner
                      if ((is==    1) .and. (je==npy-1)) q(1-j  ,npy+i) = q(i+1  ,npy+j  )  !NW Corner
                      if ((ie==npx-1) .and. (js==    1)) q(npx+j,1-i  ) = q(npx-i,1-j    )  !SE Corner
                      if ((ie==npx-1) .and. (je==npy-1)) q(npx+j,npy+i) = q(npx-i,npy+j  )  !NE Corner
@@ -997,7 +997,7 @@ end subroutine switch_current_Atm
               case default
                  do j=1,ng
                     do i=1,ng
-                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner 
+                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner
                      if ((is==    1) .and. (je==npy-1)) q(1-i  ,npy+j) = q(1-j  ,npy-i  )  !NW Corner
                      if ((ie==npx-1) .and. (js==    1)) q(npx+i,1-j  ) = q(npx+j,i+1    )  !SE Corner
                      if ((ie==npx-1) .and. (je==npy-1)) q(npx+i,npy+j) = q(npx+j,npy-i  )  !NE Corner
@@ -1011,7 +1011,7 @@ end subroutine switch_current_Atm
               case (XDir)
                  do j=1,ng
                     do i=1,ng
-                       if ((is==    1) .and. (js==    1)) q(1-i    ,1-j    ) = q(1-j    ,i        )  !SW Corner 
+                       if ((is==    1) .and. (js==    1)) q(1-i    ,1-j    ) = q(1-j    ,i        )  !SW Corner
                        if ((is==    1) .and. (je==npy-1)) q(1-i    ,npy-1+j) = q(1-j    ,npy-1-i+1)  !NW Corner
                        if ((ie==npx-1) .and. (js==    1)) q(npx-1+i,1-j    ) = q(npx-1+j,i        )  !SE Corner
                        if ((ie==npx-1) .and. (je==npy-1)) q(npx-1+i,npy-1+j) = q(npx-1+j,npy-1-i+1)  !NE Corner
@@ -1020,7 +1020,7 @@ end subroutine switch_current_Atm
               case (YDir)
                  do j=1,ng
                     do i=1,ng
-                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner 
+                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner
                        if ((is==    1) .and. (je==npy-1)) q(1-j    ,npy-1+i) = q(i        ,npy-1+j)  !NW Corner
                        if ((ie==npx-1) .and. (js==    1)) q(npx-1+j,1-i    ) = q(npx-1-i+1,1-j    )  !SE Corner
                        if ((ie==npx-1) .and. (je==npy-1)) q(npx-1+j,npy-1+i) = q(npx-1-i+1,npy-1+j)  !NE Corner
@@ -1028,13 +1028,13 @@ end subroutine switch_current_Atm
                  enddo
               case default
                  do j=1,ng
-                    do i=1,ng        
-                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner 
+                    do i=1,ng
+                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner
                        if ((is==    1) .and. (je==npy-1)) q(1-j    ,npy-1+i) = q(i        ,npy-1+j)  !NW Corner
                        if ((ie==npx-1) .and. (js==    1)) q(npx-1+j,1-i    ) = q(npx-1-i+1,1-j    )  !SE Corner
                        if ((ie==npx-1) .and. (je==npy-1)) q(npx-1+j,npy-1+i) = q(npx-1-i+1,npy-1+j)  !NE Corner
                    enddo
-                 enddo          
+                 enddo
               end select
             endif
           endif
@@ -1045,12 +1045,12 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !!
-!     
+!
       subroutine fill_corners_2d_r8(q, npx, npy, FILL, AGRID, BGRID)
          real(kind=8), DIMENSION(isd:,jsd:), intent(INOUT):: q
          integer, intent(IN):: npx,npy
-         integer, intent(IN):: FILL  ! X-Dir or Y-Dir 
-         logical, OPTIONAL, intent(IN) :: AGRID, BGRID 
+         integer, intent(IN):: FILL  ! X-Dir or Y-Dir
+         logical, OPTIONAL, intent(IN) :: AGRID, BGRID
          integer :: i,j
 
          if (present(BGRID)) then
@@ -1059,7 +1059,7 @@ end subroutine switch_current_Atm
               case (XDir)
                  do j=1,ng
                     do i=1,ng
-                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner 
+                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner
                      if ((is==    1) .and. (je==npy-1)) q(1-i  ,npy+j) = q(1-j  ,npy-i  )  !NW Corner
                      if ((ie==npx-1) .and. (js==    1)) q(npx+i,1-j  ) = q(npx+j,i+1    )  !SE Corner
                      if ((ie==npx-1) .and. (je==npy-1)) q(npx+i,npy+j) = q(npx+j,npy-i  )  !NE Corner
@@ -1068,7 +1068,7 @@ end subroutine switch_current_Atm
               case (YDir)
                  do j=1,ng
                     do i=1,ng
-                     if ((is==    1) .and. (js==    1)) q(1-j  ,1-i  ) = q(i+1  ,1-j    )  !SW Corner 
+                     if ((is==    1) .and. (js==    1)) q(1-j  ,1-i  ) = q(i+1  ,1-j    )  !SW Corner
                      if ((is==    1) .and. (je==npy-1)) q(1-j  ,npy+i) = q(i+1  ,npy+j  )  !NW Corner
                      if ((ie==npx-1) .and. (js==    1)) q(npx+j,1-i  ) = q(npx-i,1-j    )  !SE Corner
                      if ((ie==npx-1) .and. (je==npy-1)) q(npx+j,npy+i) = q(npx-i,npy+j  )  !NE Corner
@@ -1077,7 +1077,7 @@ end subroutine switch_current_Atm
               case default
                  do j=1,ng
                     do i=1,ng
-                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner 
+                     if ((is==    1) .and. (js==    1)) q(1-i  ,1-j  ) = q(1-j  ,i+1    )  !SW Corner
                      if ((is==    1) .and. (je==npy-1)) q(1-i  ,npy+j) = q(1-j  ,npy-i  )  !NW Corner
                      if ((ie==npx-1) .and. (js==    1)) q(npx+i,1-j  ) = q(npx+j,i+1    )  !SE Corner
                      if ((ie==npx-1) .and. (je==npy-1)) q(npx+i,npy+j) = q(npx+j,npy-i  )  !NE Corner
@@ -1091,7 +1091,7 @@ end subroutine switch_current_Atm
               case (XDir)
                  do j=1,ng
                     do i=1,ng
-                       if ((is==    1) .and. (js==    1)) q(1-i    ,1-j    ) = q(1-j    ,i        )  !SW Corner 
+                       if ((is==    1) .and. (js==    1)) q(1-i    ,1-j    ) = q(1-j    ,i        )  !SW Corner
                        if ((is==    1) .and. (je==npy-1)) q(1-i    ,npy-1+j) = q(1-j    ,npy-1-i+1)  !NW Corner
                        if ((ie==npx-1) .and. (js==    1)) q(npx-1+i,1-j    ) = q(npx-1+j,i        )  !SE Corner
                        if ((ie==npx-1) .and. (je==npy-1)) q(npx-1+i,npy-1+j) = q(npx-1+j,npy-1-i+1)  !NE Corner
@@ -1100,7 +1100,7 @@ end subroutine switch_current_Atm
               case (YDir)
                  do j=1,ng
                     do i=1,ng
-                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner 
+                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner
                        if ((is==    1) .and. (je==npy-1)) q(1-j    ,npy-1+i) = q(i        ,npy-1+j)  !NW Corner
                        if ((ie==npx-1) .and. (js==    1)) q(npx-1+j,1-i    ) = q(npx-1-i+1,1-j    )  !SE Corner
                        if ((ie==npx-1) .and. (je==npy-1)) q(npx-1+j,npy-1+i) = q(npx-1-i+1,npy-1+j)  !NE Corner
@@ -1108,13 +1108,13 @@ end subroutine switch_current_Atm
                  enddo
               case default
                  do j=1,ng
-                    do i=1,ng        
-                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner 
+                    do i=1,ng
+                       if ((is==    1) .and. (js==    1)) q(1-j    ,1-i    ) = q(i        ,1-j    )  !SW Corner
                        if ((is==    1) .and. (je==npy-1)) q(1-j    ,npy-1+i) = q(i        ,npy-1+j)  !NW Corner
                        if ((ie==npx-1) .and. (js==    1)) q(npx-1+j,1-i    ) = q(npx-1-i+1,1-j    )  !SE Corner
                        if ((ie==npx-1) .and. (je==npy-1)) q(npx-1+j,npy-1+i) = q(npx-1-i+1,npy-1+j)  !NE Corner
                    enddo
-                 enddo          
+                 enddo
               end select
             endif
           endif
@@ -1275,16 +1275,16 @@ end subroutine switch_current_Atm
          real(kind=8), DIMENSION(isd:,jsd:), intent(INOUT):: x
          real(kind=8), DIMENSION(isd:,jsd:), intent(INOUT):: y
          integer, intent(IN):: npx,npy
-         real(kind=8), intent(IN) :: mySign 
+         real(kind=8), intent(IN) :: mySign
          integer :: i,j
 
                do j=1,ng
                   do i=1,ng
-                   !   if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) =        y(j+1  ,1-i    )  !SW Corner 
+                   !   if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) =        y(j+1  ,1-i    )  !SW Corner
                    !   if ((is  ==  1) .and. (je+1==npy)) x(1-i    ,npy+j) = mySign*y(j+1  ,npy-1+i)  !NW Corner
                    !   if ((ie+1==npx) .and. (js  ==  1)) x(npx-1+i,1-j  ) = mySign*y(npx-j,1-i    )  !SE Corner
                    !   if ((ie+1==npx) .and. (je+1==npy)) x(npx-1+i,npy+j) =        y(npx-j,npy-1+i)  !NE Corner
-                      if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) = mySign*y(1-j  ,i    )  !SW Corner 
+                      if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) = mySign*y(1-j  ,i    )  !SW Corner
                       if ((is  ==  1) .and. (je+1==npy)) x(1-i    ,npy+j) =        y(1-j  ,npy-i)  !NW Corner
                       if ((ie+1==npx) .and. (js  ==  1)) x(npx-1+i,1-j  ) =        y(npx+j,i    )  !SE Corner
                       if ((ie+1==npx) .and. (je+1==npy)) x(npx-1+i,npy+j) = mySign*y(npx+j,npy-i)  !NE Corner
@@ -1292,11 +1292,11 @@ end subroutine switch_current_Atm
                enddo
                do j=1,ng
                   do i=1,ng
-                   !  if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) =        x(1-j    ,i+1  )  !SW Corner 
+                   !  if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) =        x(1-j    ,i+1  )  !SW Corner
                    !  if ((is  ==  1) .and. (je+1==npy)) y(1-i    ,npy-1+j) = mySign*x(1-j    ,npy-i)  !NW Corner
                    !  if ((ie+1==npx) .and. (js  ==  1)) y(npx+i  ,1-j    ) = mySign*x(npx-1+j,i+1  )  !SE Corner
                    !  if ((ie+1==npx) .and. (je+1==npy)) y(npx+i  ,npy-1+j) =        x(npx-1+j,npy-i)  !NE Corner
-                     if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) = mySign*x(j      ,1-i  )  !SW Corner 
+                     if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) = mySign*x(j      ,1-i  )  !SW Corner
                      if ((is  ==  1) .and. (je+1==npy)) y(1-i    ,npy-1+j) =        x(j      ,npy+i)  !NW Corner
                      if ((ie+1==npx) .and. (js  ==  1)) y(npx+i  ,1-j    ) =        x(npx-j  ,1-i  )  !SE Corner
                      if ((ie+1==npx) .and. (je+1==npy)) y(npx+i  ,npy-1+j) = mySign*x(npx-j  ,npy+i)  !NE Corner
@@ -1315,16 +1315,16 @@ end subroutine switch_current_Atm
          real(kind=4), DIMENSION(isd:,jsd:), intent(INOUT):: x
          real(kind=4), DIMENSION(isd:,jsd:), intent(INOUT):: y
          integer, intent(IN):: npx,npy
-         real(kind=4), intent(IN) :: mySign 
+         real(kind=4), intent(IN) :: mySign
          integer :: i,j
 
                do j=1,ng
                   do i=1,ng
-                   !   if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) =        y(j+1  ,1-i    )  !SW Corner 
+                   !   if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) =        y(j+1  ,1-i    )  !SW Corner
                    !   if ((is  ==  1) .and. (je+1==npy)) x(1-i    ,npy+j) = mySign*y(j+1  ,npy-1+i)  !NW Corner
                    !   if ((ie+1==npx) .and. (js  ==  1)) x(npx-1+i,1-j  ) = mySign*y(npx-j,1-i    )  !SE Corner
                    !   if ((ie+1==npx) .and. (je+1==npy)) x(npx-1+i,npy+j) =        y(npx-j,npy-1+i)  !NE Corner
-                      if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) = mySign*y(1-j  ,i    )  !SW Corner 
+                      if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j  ) = mySign*y(1-j  ,i    )  !SW Corner
                       if ((is  ==  1) .and. (je+1==npy)) x(1-i    ,npy+j) =        y(1-j  ,npy-i)  !NW Corner
                       if ((ie+1==npx) .and. (js  ==  1)) x(npx-1+i,1-j  ) =        y(npx+j,i    )  !SE Corner
                       if ((ie+1==npx) .and. (je+1==npy)) x(npx-1+i,npy+j) = mySign*y(npx+j,npy-i)  !NE Corner
@@ -1332,11 +1332,11 @@ end subroutine switch_current_Atm
                enddo
                do j=1,ng
                   do i=1,ng
-                   !  if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) =        x(1-j    ,i+1  )  !SW Corner 
+                   !  if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) =        x(1-j    ,i+1  )  !SW Corner
                    !  if ((is  ==  1) .and. (je+1==npy)) y(1-i    ,npy-1+j) = mySign*x(1-j    ,npy-i)  !NW Corner
                    !  if ((ie+1==npx) .and. (js  ==  1)) y(npx+i  ,1-j    ) = mySign*x(npx-1+j,i+1  )  !SE Corner
                    !  if ((ie+1==npx) .and. (je+1==npy)) y(npx+i  ,npy-1+j) =        x(npx-1+j,npy-i)  !NE Corner
-                     if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) = mySign*x(j      ,1-i  )  !SW Corner 
+                     if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j    ) = mySign*x(j      ,1-i  )  !SW Corner
                      if ((is  ==  1) .and. (je+1==npy)) y(1-i    ,npy-1+j) =        x(j      ,npy+i)  !NW Corner
                      if ((ie+1==npx) .and. (js  ==  1)) y(npx+i  ,1-j    ) =        x(npx-j  ,1-i  )  !SE Corner
                      if ((ie+1==npx) .and. (je+1==npy)) y(npx+i  ,npy-1+j) = mySign*x(npx-j  ,npy+i)  !NE Corner
@@ -1360,7 +1360,7 @@ end subroutine switch_current_Atm
 
                   do j=1,ng
                      do i=1,ng
-                        if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j    ) =        y(j      ,1-i  )  !SW Corner 
+                        if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j    ) =        y(j      ,1-i  )  !SW Corner
                         if ((is  ==  1) .and. (je+1==npy)) x(1-i    ,npy-1+j) = mySign*y(j      ,npy+i)  !NW Corner
                         if ((ie+1==npx) .and. (js  ==  1)) x(npx+i  ,1-j    ) = mySign*y(npx-j  ,1-i  )  !SE Corner
                         if ((ie+1==npx) .and. (je+1==npy)) x(npx+i  ,npy-1+j) =        y(npx-j  ,npy+i)  !NE Corner
@@ -1368,13 +1368,13 @@ end subroutine switch_current_Atm
                   enddo
                   do j=1,ng
                      do i=1,ng
-                        if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j  ) =        x(1-j  ,i    )  !SW Corner 
+                        if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j  ) =        x(1-j  ,i    )  !SW Corner
                         if ((is  ==  1) .and. (je+1==npy)) y(1-i    ,npy+j) = mySign*x(1-j  ,npy-i)  !NW Corner
                         if ((ie+1==npx) .and. (js  ==  1)) y(npx-1+i,1-j  ) = mySign*x(npx+j,i    )  !SE Corner
                         if ((ie+1==npx) .and. (je+1==npy)) y(npx-1+i,npy+j) =        x(npx+j,npy-i)  !NE Corner
                      enddo
                   enddo
-      
+
       end subroutine fill_corners_cgrid_r4
 !
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
@@ -1392,7 +1392,7 @@ end subroutine switch_current_Atm
 
                   do j=1,ng
                      do i=1,ng
-                        if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j    ) =        y(j      ,1-i  )  !SW Corner 
+                        if ((is  ==  1) .and. (js  ==  1)) x(1-i    ,1-j    ) =        y(j      ,1-i  )  !SW Corner
                         if ((is  ==  1) .and. (je+1==npy)) x(1-i    ,npy-1+j) = mySign*y(j      ,npy+i)  !NW Corner
                         if ((ie+1==npx) .and. (js  ==  1)) x(npx+i  ,1-j    ) = mySign*y(npx-j  ,1-i  )  !SE Corner
                         if ((ie+1==npx) .and. (je+1==npy)) x(npx+i  ,npy-1+j) =        y(npx-j  ,npy+i)  !NE Corner
@@ -1400,13 +1400,13 @@ end subroutine switch_current_Atm
                   enddo
                   do j=1,ng
                      do i=1,ng
-                        if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j  ) =        x(1-j  ,i    )  !SW Corner 
+                        if ((is  ==  1) .and. (js  ==  1)) y(1-i    ,1-j  ) =        x(1-j  ,i    )  !SW Corner
                         if ((is  ==  1) .and. (je+1==npy)) y(1-i    ,npy+j) = mySign*x(1-j  ,npy-i)  !NW Corner
                         if ((ie+1==npx) .and. (js  ==  1)) y(npx-1+i,1-j  ) = mySign*x(npx+j,i    )  !SE Corner
                         if ((ie+1==npx) .and. (je+1==npy)) y(npx-1+i,npy+j) =        x(npx+j,npy-i)  !NE Corner
                      enddo
                   enddo
-      
+
       end subroutine fill_corners_cgrid_r8
 !
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
@@ -1478,11 +1478,11 @@ end subroutine switch_current_Atm
 
 !!$!-------------------------------------------------------------------------------
 !!$! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!!$!     
+!!$!
 !!$!     mp_corner_comm :: Point-based MPI communcation routine for Cubed-Sphere
-!!$!                       ghosted corner point on B-Grid 
-!!$!                       this routine sends 24 16-byte messages 
-!!$!     
+!!$!                       ghosted corner point on B-Grid
+!!$!                       this routine sends 24 16-byte messages
+!!$!
 !!$      subroutine mp_corner_comm(q, npx, npy, tile)
 !!$         integer, intent(IN)  :: npx,npy, tile
 !!$         real  , intent(INOUT):: q(isd:ied+1,jsd:jed+1)
@@ -1521,7 +1521,7 @@ end subroutine switch_current_Atm
 !!$                                     src_gid, recv_tag, &
 !!$                                     commglobal, Stats, ierror )
 !!$                  nsend=nsend-1
-!!$               else 
+!!$               else
 !!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &
 !!$                                  send_tag, commglobal, sqest(nsend), ierror )
 !!$                  nrecv=nrecv+1
@@ -1594,7 +1594,7 @@ end subroutine switch_current_Atm
 !!$                                  recv_tag, commglobal, rqest(nrecv), ierror )
 !!$               endif
 !!$            endif
-!!$            if ( (tile==4) .and. (ie==npx-1) .and. (js==1) ) then 
+!!$            if ( (tile==4) .and. (ie==npx-1) .and. (js==1) ) then
 !!$               nsend=nsend+1
 !!$               qsend(nsend) = q(ie+1,js+1)
 !!$               send_tag = 200+tile
@@ -1602,14 +1602,14 @@ end subroutine switch_current_Atm
 !!$               recv_tag = 200+(tile-2)
 !!$               src_gid  = dest_gid
 !!$               if (npes>6) then
-!!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &     
+!!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &
 !!$                                     dest_gid, send_tag, &
 !!$                                     q(ie+2,js), 1, MPI_DOUBLE_PRECISION, &
-!!$                                     src_gid, recv_tag, &          
+!!$                                     src_gid, recv_tag, &
 !!$                                     commglobal, Stats, ierror )
 !!$                  nsend=nsend-1
 !!$               else
-!!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &        
+!!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &
 !!$                                  send_tag, commglobal, sqest(nsend), ierror )
 !!$                  nrecv=nrecv+1
 !!$                  call MPI_IRECV( q(ie+2,js), 1, MPI_DOUBLE_PRECISION, src_gid,  &
@@ -1630,7 +1630,7 @@ end subroutine switch_current_Atm
 !!$                               recv_tag, commglobal, rqest(nrecv), ierror )
 !!$            endif
 !!$
-!!$! wait for comm to complete 
+!!$! wait for comm to complete
 !!$            if (npes==6) then
 !!$               if (nsend>0) then
 !!$                  call MPI_WAITALL(nsend, sqest, Stats, ierror)
@@ -1684,10 +1684,10 @@ end subroutine switch_current_Atm
 !!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &
 !!$                                     dest_gid, send_tag, &
 !!$                                     q(is-1,js), 1, MPI_DOUBLE_PRECISION, &
-!!$                                     src_gid, recv_tag, &             
+!!$                                     src_gid, recv_tag, &
 !!$                                     commglobal, Stats, ierror )
 !!$                  nsend=nsend-1
-!!$               else 
+!!$               else
 !!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &
 !!$                                  send_tag, commglobal, sqest(nsend), ierror )
 !!$                  nrecv=nrecv+1
@@ -1706,13 +1706,13 @@ end subroutine switch_current_Atm
 !!$               src_gid  = (tile+1)*npes_x*npes_y
 !!$               if (src_gid+1 > npes) src_gid=src_gid-npes
 !!$               if (npes>6) then
-!!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &      
+!!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &
 !!$                                     dest_gid, send_tag, &
 !!$                                     q(ie+2,je+1), 1, MPI_DOUBLE_PRECISION, &
-!!$                                     src_gid, recv_tag, &             
+!!$                                     src_gid, recv_tag, &
 !!$                                     commglobal, Stats, ierror )
 !!$                  nsend=nsend-1
-!!$               else 
+!!$               else
 !!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &
 !!$                                  send_tag, commglobal, sqest(nsend), ierror )
 !!$                  nrecv=nrecv+1
@@ -1720,7 +1720,7 @@ end subroutine switch_current_Atm
 !!$                                  recv_tag, commglobal, rqest(nrecv), ierror )
 !!$               endif
 !!$            endif
-!!$! wait for comm to complete 
+!!$! wait for comm to complete
 !!$            if (npes==6) then
 !!$               if (nsend>0) then
 !!$                  call MPI_WAITALL(nsend, sqest, Stats, ierror)
@@ -1736,7 +1736,7 @@ end subroutine switch_current_Atm
 !!$               endif
 !!$               nsend=0 ; nrecv=0
 !!$            endif
-!!$            
+!!$
 !!$! Odd Face UL 1 pair ; 1 1-way
 !!$            if ( (tile==1) .and. (is==1) .and. (je==npy-1) ) then
 !!$               nsend=nsend+1
@@ -1765,22 +1765,22 @@ end subroutine switch_current_Atm
 !!$               qsend(nsend) = q(is+1,je+1)
 !!$               send_tag = 400+tile
 !!$               dest_gid = npes_x*(npes_y-1)
-!!$               recv_tag = 400+(tile-2)           
+!!$               recv_tag = 400+(tile-2)
 !!$               src_gid  = dest_gid
 !!$               if (npes>6) then
-!!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &     
+!!$                  call MPI_SENDRECV( qsend(nsend), 1, MPI_DOUBLE_PRECISION, &
 !!$                                     dest_gid, send_tag, &
 !!$                                     q(is-1,je+1), 1, MPI_DOUBLE_PRECISION, &
-!!$                                     src_gid, recv_tag, &          
+!!$                                     src_gid, recv_tag, &
 !!$                                     commglobal, Stats, ierror )
-!!$                  nsend=nsend-1             
+!!$                  nsend=nsend-1
 !!$               else
-!!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &        
+!!$                  call MPI_ISEND( qsend(nsend), 1, MPI_DOUBLE_PRECISION, dest_gid, &
 !!$                                  send_tag, commglobal, sqest(nsend), ierror )
 !!$                  nrecv=nrecv+1
 !!$                  call MPI_IRECV( q(is-1,je+1), 1, MPI_DOUBLE_PRECISION, src_gid,  &
 !!$                                  recv_tag, commglobal, rqest(nrecv), ierror )
-!!$               endif            
+!!$               endif
 !!$               nsend=nsend+1
 !!$               qsend(nsend) = q(is,je)
 !!$               send_tag = 400+tile
@@ -1791,12 +1791,12 @@ end subroutine switch_current_Atm
 !!$            if ( (tile==5) .and. (is==1) .and. (je==npy-1) ) then
 !!$               recv_tag = 400+(tile-2)
 !!$               src_gid  = (tile-3)*npes_x*npes_y + npes_x*(npes_y-1)
-!!$               nrecv=nrecv+1 
+!!$               nrecv=nrecv+1
 !!$               call MPI_IRECV( q(is-1,je+1), 1, MPI_DOUBLE_PRECISION, src_gid,  &
-!!$                               recv_tag, commglobal, rqest(nrecv), ierror ) 
+!!$                               recv_tag, commglobal, rqest(nrecv), ierror )
 !!$            endif
 !!$
-!!$! wait for comm to complete 
+!!$! wait for comm to complete
 !!$            if (npes==6) then
 !!$               if (nsend>0) then
 !!$                  call MPI_WAITALL(nsend, sqest, Stats, ierror)
@@ -1813,7 +1813,7 @@ end subroutine switch_current_Atm
 !!$               nsend=0 ; nrecv=0
 !!$            endif
 !!$
-!!$! Send to Even face UL 3 1-way 
+!!$! Send to Even face UL 3 1-way
 !!$            if ( (ie==npx-1) .and. (je==npy-1) ) then
 !!$               nsend=nsend+1
 !!$               qsend(nsend) = q(ie,je+1)
@@ -1826,7 +1826,7 @@ end subroutine switch_current_Atm
 !!$! Receive Odd Face LR 3 1-way
 !!$            if ( (ie==npx-1) .and. (js==1) ) then
 !!$               recv_tag = 200+(tile+1)
-!!$               src_gid  = (tile-1)*npes_x*npes_y + npes_x*npes_y 
+!!$               src_gid  = (tile-1)*npes_x*npes_y + npes_x*npes_y
 !!$               nrecv=nrecv+1
 !!$               call MPI_IRECV( q(ie+2,js), 1, MPI_DOUBLE_PRECISION, src_gid,  &
 !!$                               recv_tag, commglobal, rqest(nrecv), ierror )
@@ -1855,37 +1855,37 @@ end subroutine switch_current_Atm
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!       
-!     mp_gather_4d_r4 :: Call SPMD Gather 
-!     
+!
+!     mp_gather_4d_r4 :: Call SPMD Gather
+!
       subroutine mp_gather_4d_r4(q, i1,i2, j1,j2, idim, jdim, kdim, ldim)
          integer, intent(IN)  :: i1,i2, j1,j2
          integer, intent(IN)  :: idim, jdim, kdim, ldim
          real(kind=4), intent(INOUT):: q(idim,jdim,kdim,ldim)
-         integer :: i,j,k,l,n,icnt 
+         integer :: i,j,k,l,n,icnt
          integer :: Lsize, Lsize_buf(1)
          integer :: Gsize
          integer :: LsizeS(npes_this_grid), Ldispl(npes_this_grid), cnts(npes_this_grid)
          integer :: Ldims(5), Gdims(5*npes_this_grid)
          real(kind=4), allocatable, dimension(:) :: larr, garr
-        
+
          Ldims(1) = i1
          Ldims(2) = i2
          Ldims(3) = j1
          Ldims(4) = j2
-         Ldims(5) = tile 
+         Ldims(5) = tile
          do l=1,npes_this_grid
             cnts(l) = 5
             Ldispl(l) = 5*(l-1)
-         enddo 
+         enddo
          call mpp_gather(Ldims, Gdims)
 !         call MPI_GATHERV(Ldims, 5, MPI_INTEGER, Gdims, cnts, Ldispl, MPI_INTEGER, masterproc, commglobal, ierror)
-      
+
          Lsize = ( (i2 - i1 + 1) * (j2 - j1 + 1) ) * kdim
          do l=1,npes_this_grid
             cnts(l) = 1
             Ldispl(l) = l-1
-         enddo 
+         enddo
          LsizeS(:)=1
          Lsize_buf(1) = Lsize
          call mpp_gather(Lsize_buf, LsizeS)
@@ -1942,18 +1942,18 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_gather_3d_r4 :: Call SPMD Gather 
+!     mp_gather_3d_r4 :: Call SPMD Gather
 !
       subroutine mp_gather_3d_r4(q, i1,i2, j1,j2, idim, jdim, ldim)
          integer, intent(IN)  :: i1,i2, j1,j2
          integer, intent(IN)  :: idim, jdim, ldim
          real(kind=4), intent(INOUT):: q(idim,jdim,ldim)
-         integer :: i,j,l,n,icnt 
+         integer :: i,j,l,n,icnt
          integer :: Lsize, Lsize_buf(1)
          integer :: Gsize
          integer :: LsizeS(npes_this_grid), Ldispl(npes_this_grid), cnts(npes_this_grid)
          integer :: Ldims(5), Gdims(5*npes_this_grid)
-         real(kind=4), allocatable, dimension(:) :: larr, garr 
+         real(kind=4), allocatable, dimension(:) :: larr, garr
 
          Ldims(1) = i1
          Ldims(2) = i2
@@ -1971,7 +1971,7 @@ end subroutine switch_current_Atm
          do l=1,npes_this_grid
             cnts(l) = 1
             Ldispl(l) = l-1
-         enddo 
+         enddo
          LsizeS(:)=1
          Lsize_buf(1) = Lsize
          call mpp_gather(Lsize_buf, LsizeS)
@@ -1981,7 +1981,7 @@ end subroutine switch_current_Atm
          icnt = 1
          do j=j1,j2
             do i=i1,i2
-               larr(icnt) = q(i,j,tile)  
+               larr(icnt) = q(i,j,tile)
                icnt=icnt+1
             enddo
          enddo
@@ -2001,7 +2001,7 @@ end subroutine switch_current_Atm
             do n=2,npes_this_grid
                icnt=1
                do l=Gdims( (n-1)*5 + 5 ), Gdims( (n-1)*5 + 5 )
-                  do j=Gdims( (n-1)*5 + 3 ), Gdims( (n-1)*5 + 4 ) 
+                  do j=Gdims( (n-1)*5 + 3 ), Gdims( (n-1)*5 + 4 )
                      do i=Gdims( (n-1)*5 + 1 ), Gdims( (n-1)*5 + 2 )
                         q(i,j,l) = garr(Ldispl(n)+icnt)
                         icnt=icnt+1
@@ -2021,7 +2021,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_gather_3d_r8 :: Call SPMD Gather 
+!     mp_gather_3d_r8 :: Call SPMD Gather
 !
       subroutine mp_gather_3d_r8(q, i1,i2, j1,j2, idim, jdim, ldim)
          integer, intent(IN)  :: i1,i2, j1,j2
@@ -2101,7 +2101,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_i4 :: Call SPMD broadcast 
+!     mp_bcst_i4 :: Call SPMD broadcast
 !
       subroutine mp_bcst_i4(q)
          integer, intent(INOUT)  :: q
@@ -2116,7 +2116,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_r4 :: Call SPMD broadcast 
+!     mp_bcst_r4 :: Call SPMD broadcast
 !
       subroutine mp_bcst_r4(q)
          real(kind=4), intent(INOUT)  :: q
@@ -2131,7 +2131,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_r8 :: Call SPMD broadcast 
+!     mp_bcst_r8 :: Call SPMD broadcast
 !
       subroutine mp_bcst_r8(q)
          real(kind=8), intent(INOUT)  :: q
@@ -2146,7 +2146,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_3d_r4 :: Call SPMD broadcast 
+!     mp_bcst_3d_r4 :: Call SPMD broadcast
 !
       subroutine mp_bcst_3d_r4(q, idim, jdim, kdim)
          integer, intent(IN)  :: idim, jdim, kdim
@@ -2162,7 +2162,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_3d_r8 :: Call SPMD broadcast 
+!     mp_bcst_3d_r8 :: Call SPMD broadcast
 !
       subroutine mp_bcst_3d_r8(q, idim, jdim, kdim)
          integer, intent(IN)  :: idim, jdim, kdim
@@ -2177,33 +2177,33 @@ end subroutine switch_current_Atm
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!       
-!     mp_bcst_4d_r4 :: Call SPMD broadcast 
+!
+!     mp_bcst_4d_r4 :: Call SPMD broadcast
 !
       subroutine mp_bcst_4d_r4(q, idim, jdim, kdim, ldim)
          integer, intent(IN)  :: idim, jdim, kdim, ldim
          real(kind=4), intent(INOUT)  :: q(idim,jdim,kdim,ldim)
 
          call MPI_BCAST(q, idim*jdim*kdim*ldim, MPI_REAL, masterproc, commglobal, ierror)
-        
+
       end subroutine mp_bcst_4d_r4
-!     
+!
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
 !-------------------------------------------------------------------------------
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!       
-!     mp_bcst_4d_r8 :: Call SPMD broadcast 
+!
+!     mp_bcst_4d_r8 :: Call SPMD broadcast
 !
       subroutine mp_bcst_4d_r8(q, idim, jdim, kdim, ldim)
          integer, intent(IN)  :: idim, jdim, kdim, ldim
          real(kind=8), intent(INOUT)  :: q(idim,jdim,kdim,ldim)
 
          call MPI_BCAST(q, idim*jdim*kdim*ldim, MPI_DOUBLE_PRECISION, masterproc, commglobal, ierror)
-        
+
       end subroutine mp_bcst_4d_r8
-!     
+!
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
 !-------------------------------------------------------------------------------
 
@@ -2242,44 +2242,44 @@ end subroutine switch_current_Atm
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!       
-!     mp_reduce_max_r4_1d :: Call SPMD REDUCE_MAX 
+!
+!     mp_reduce_max_r4_1d :: Call SPMD REDUCE_MAX
 !
       subroutine mp_reduce_max_r4_1d(mymax,npts)
          integer, intent(IN)  :: npts
          real(kind=4), intent(INOUT)  :: mymax(npts)
-        
+
          real(kind=4) :: gmax(npts)
-        
+
          call MPI_ALLREDUCE( mymax, gmax, npts, MPI_REAL, MPI_MAX, &
                              commglobal, ierror )
-      
+
          mymax = gmax
-        
+
       end subroutine mp_reduce_max_r4_1d
-!     
+!
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
 !-------------------------------------------------------------------------------
 
 
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
-!       
-!     mp_reduce_max_r8_1d :: Call SPMD REDUCE_MAX 
+!
+!     mp_reduce_max_r8_1d :: Call SPMD REDUCE_MAX
 !
       subroutine mp_reduce_max_r8_1d(mymax,npts)
          integer, intent(IN)  :: npts
          real(kind=8), intent(INOUT)  :: mymax(npts)
-        
+
          real(kind=8) :: gmax(npts)
-        
+
          call MPI_ALLREDUCE( mymax, gmax, npts, MPI_DOUBLE_PRECISION, MPI_MAX, &
                              commglobal, ierror )
-      
+
          mymax = gmax
-        
+
       end subroutine mp_reduce_max_r8_1d
-!     
+!
 ! ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ !
 !-------------------------------------------------------------------------------
 
@@ -2287,7 +2287,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_reduce_max_r4 :: Call SPMD REDUCE_MAX 
+!     mp_reduce_max_r4 :: Call SPMD REDUCE_MAX
 !
       subroutine mp_reduce_max_r4(mymax)
          real(kind=4), intent(INOUT)  :: mymax
@@ -2304,7 +2304,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_reduce_max_r8 :: Call SPMD REDUCE_MAX 
+!     mp_reduce_max_r8 :: Call SPMD REDUCE_MAX
 !
       subroutine mp_reduce_max_r8(mymax)
          real(kind=8), intent(INOUT)  :: mymax
@@ -2348,7 +2348,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_bcst_4d_i4 :: Call SPMD REDUCE_MAX 
+!     mp_bcst_4d_i4 :: Call SPMD REDUCE_MAX
 !
       subroutine mp_reduce_max_i4(mymax)
          integer, intent(INOUT)  :: mymax
@@ -2368,7 +2368,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_reduce_sum_r4 :: Call SPMD REDUCE_SUM 
+!     mp_reduce_sum_r4 :: Call SPMD REDUCE_SUM
 !
       subroutine mp_reduce_sum_r4(mysum)
          real(kind=4), intent(INOUT)  :: mysum
@@ -2388,7 +2388,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_reduce_sum_r8 :: Call SPMD REDUCE_SUM 
+!     mp_reduce_sum_r8 :: Call SPMD REDUCE_SUM
 !
       subroutine mp_reduce_sum_r8(mysum)
          real(kind=8), intent(INOUT)  :: mysum
@@ -2408,7 +2408,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_reduce_sum_r4_1d :: Call SPMD REDUCE_SUM 
+!     mp_reduce_sum_r4_1d :: Call SPMD REDUCE_SUM
 !
       subroutine mp_reduce_sum_r4_1d(mysum, sum1d, npts)
          integer, intent(in)  :: npts
@@ -2421,7 +2421,7 @@ end subroutine switch_current_Atm
          mysum = 0.0
          do i=1,npts
             mysum = mysum + sum1d(i)
-         enddo 
+         enddo
 
          call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                              commglobal, ierror )
@@ -2436,7 +2436,7 @@ end subroutine switch_current_Atm
 !-------------------------------------------------------------------------------
 ! vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv !
 !
-!     mp_reduce_sum_r8_1d :: Call SPMD REDUCE_SUM 
+!     mp_reduce_sum_r8_1d :: Call SPMD REDUCE_SUM
 !
       subroutine mp_reduce_sum_r8_1d(mysum, sum1d, npts)
          integer, intent(in)  :: npts
@@ -2449,7 +2449,7 @@ end subroutine switch_current_Atm
          mysum = 0.0
          do i=1,npts
             mysum = mysum + sum1d(i)
-         enddo 
+         enddo
 
          call MPI_ALLREDUCE( mysum, gsum, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                              commglobal, ierror )


### PR DESCRIPTION
This PR has updates needed to compile GEOSagcmPert with FMS 2024. This is the version of FMS used in GEOSgcm v12 (and v11.10.0) and so when I tried to build it with the latest GEOSgcm setup, things failed.

NOTE: This is *NOT* backwards compatible. You can't use this code with older FMS.